### PR TITLE
feat: add attack resolution skill with SRD 5e rules

### DIFF
--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -9,6 +9,27 @@ Skills are pure functions that:
 - NEVER call LLMs directly
 """
 
+from src.skills.combat import (
+    Abilities,
+    AttackResult,
+    Combatant,
+    CoverType,
+    Weapon,
+    WeaponProperty,
+    get_ability_modifier,
+    resolve_attack,
+)
 from src.skills.dice import DiceResult, roll_dice
 
-__all__ = ["roll_dice", "DiceResult"]
+__all__ = [
+    "roll_dice",
+    "DiceResult",
+    "resolve_attack",
+    "AttackResult",
+    "Combatant",
+    "Weapon",
+    "WeaponProperty",
+    "Abilities",
+    "CoverType",
+    "get_ability_modifier",
+]

--- a/src/skills/combat.py
+++ b/src/skills/combat.py
@@ -1,0 +1,208 @@
+"""
+Combat Resolution Skills.
+
+Implements SRD 5e attack resolution with strict rule enforcement.
+The Symbolic layer - no hallucination, just dice and math.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.skills.dice import roll_dice
+
+
+class CoverType(str, Enum):
+    """Cover types per SRD 5e."""
+
+    NONE = "none"
+    HALF = "half"  # +2 AC
+    THREE_QUARTERS = "three_quarters"  # +5 AC
+    TOTAL = "total"  # Can't be targeted directly
+
+
+class WeaponProperty(str, Enum):
+    """Weapon properties per SRD 5e."""
+
+    FINESSE = "finesse"  # Can use DEX instead of STR
+    RANGED = "ranged"  # Uses DEX
+    THROWN = "thrown"  # Can be thrown
+    TWO_HANDED = "two_handed"
+    VERSATILE = "versatile"
+    LIGHT = "light"
+    HEAVY = "heavy"
+
+
+class Weapon(BaseModel):
+    """A weapon used for attacks."""
+
+    name: str
+    damage_dice: str = Field(description="Damage notation, e.g., '1d8', '2d6'")
+    damage_type: str = Field(description="e.g., 'slashing', 'piercing', 'bludgeoning'")
+    properties: list[WeaponProperty] = Field(default_factory=list)
+
+
+class Abilities(BaseModel):
+    """Ability scores for an entity."""
+
+    str_: int = Field(default=10, alias="str")
+    dex: int = 10
+    con: int = 10
+    int_: int = Field(default=10, alias="int")
+    wis: int = 10
+    cha: int = 10
+
+    model_config = {"populate_by_name": True}
+
+
+class Combatant(BaseModel):
+    """Minimal combatant info needed for attack resolution."""
+
+    name: str
+    ac: int = 10
+    abilities: Abilities = Field(default_factory=Abilities)
+    proficiency_bonus: int = 2
+    proficient_weapons: list[str] = Field(default_factory=list)
+
+
+class AttackResult(BaseModel):
+    """Result of an attack roll."""
+
+    hit: bool
+    critical: bool = False
+    fumble: bool = False
+    attack_roll: int = Field(description="The natural d20 result")
+    total_attack: int = Field(description="Roll + modifiers")
+    target_ac: int
+    damage: int | None = Field(default=None, description="Only if hit")
+    damage_type: str | None = None
+
+
+def get_ability_modifier(score: int) -> int:
+    """Calculate ability modifier from score (SRD formula)."""
+    return (score - 10) // 2
+
+
+def get_attack_ability(weapon: Weapon, attacker: Combatant) -> Literal["str", "dex"]:
+    """Determine which ability to use for attack roll."""
+    if WeaponProperty.RANGED in weapon.properties:
+        return "dex"
+    if WeaponProperty.FINESSE in weapon.properties:
+        # Finesse: use higher of STR or DEX
+        str_mod = get_ability_modifier(attacker.abilities.str_)
+        dex_mod = get_ability_modifier(attacker.abilities.dex)
+        return "dex" if dex_mod > str_mod else "str"
+    return "str"
+
+
+def get_cover_bonus(cover: CoverType) -> int:
+    """Get AC bonus from cover."""
+    match cover:
+        case CoverType.NONE:
+            return 0
+        case CoverType.HALF:
+            return 2
+        case CoverType.THREE_QUARTERS:
+            return 5
+        case CoverType.TOTAL:
+            return 99  # Effectively unhittable
+
+
+def resolve_attack(
+    attacker: Combatant,
+    target: Combatant,
+    weapon: Weapon,
+    cover: CoverType = CoverType.NONE,
+    advantage: bool = False,
+    disadvantage: bool = False,
+) -> AttackResult:
+    """
+    Resolve a single attack per SRD 5e rules.
+
+    Args:
+        attacker: The attacking combatant
+        target: The target combatant
+        weapon: The weapon being used
+        cover: Target's cover (affects AC)
+        advantage: Roll 2d20 take highest
+        disadvantage: Roll 2d20 take lowest
+
+    Returns:
+        AttackResult with hit/miss, damage if hit
+
+    SRD Rules Enforced:
+        - Natural 20: Always hits, critical (double damage dice)
+        - Natural 1: Always misses (fumble)
+        - Finesse weapons can use DEX
+        - Ranged weapons use DEX
+        - Cover adds to AC
+    """
+    # Determine attack roll type
+    if advantage and not disadvantage:
+        roll_result = roll_dice("2d20kh1")
+    elif disadvantage and not advantage:
+        roll_result = roll_dice("2d20kl1")
+    else:
+        # Normal roll, or advantage and disadvantage cancel
+        roll_result = roll_dice("1d20")
+
+    natural_roll = roll_result.kept[0] if roll_result.kept else roll_result.rolls[0]
+
+    # Get ability modifier
+    attack_ability = get_attack_ability(weapon, attacker)
+    if attack_ability == "str":
+        ability_mod = get_ability_modifier(attacker.abilities.str_)
+    else:
+        ability_mod = get_ability_modifier(attacker.abilities.dex)
+
+    # Proficiency bonus
+    prof_bonus = 0
+    if weapon.name.lower() in [w.lower() for w in attacker.proficient_weapons]:
+        prof_bonus = attacker.proficiency_bonus
+
+    total_attack = natural_roll + ability_mod + prof_bonus
+
+    # Calculate effective AC with cover
+    effective_ac = target.ac + get_cover_bonus(cover)
+
+    # Determine hit/miss per SRD
+    critical = natural_roll == 20
+    fumble = natural_roll == 1
+
+    if fumble:
+        hit = False
+    elif critical:
+        hit = True
+    else:
+        hit = total_attack >= effective_ac
+
+    # Calculate damage if hit
+    damage: int | None = None
+    if hit:
+        damage_roll = roll_dice(weapon.damage_dice)
+        base_damage = damage_roll.total
+
+        # Add ability modifier to damage
+        base_damage += ability_mod
+
+        # Critical: double the dice (roll again and add)
+        if critical:
+            crit_roll = roll_dice(weapon.damage_dice)
+            base_damage += crit_roll.total
+
+        # Minimum 1 damage on hit (can't heal by attacking)
+        damage = max(1, base_damage)
+
+    return AttackResult(
+        hit=hit,
+        critical=critical,
+        fumble=fumble,
+        attack_roll=natural_roll,
+        total_attack=total_attack,
+        target_ac=effective_ac,
+        damage=damage,
+        damage_type=weapon.damage_type if hit else None,
+    )

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,361 @@
+"""Tests for combat resolution skills."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.skills.combat import (
+    Abilities,
+    AttackResult,
+    Combatant,
+    CoverType,
+    Weapon,
+    WeaponProperty,
+    get_ability_modifier,
+    get_attack_ability,
+    get_cover_bonus,
+    resolve_attack,
+)
+from src.skills.dice import DiceResult
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def fighter() -> Combatant:
+    """A typical fighter with 16 STR."""
+    return Combatant(
+        name="Fighter",
+        ac=16,
+        abilities=Abilities(str=16, dex=12, con=14, int=10, wis=10, cha=10),
+        proficiency_bonus=2,
+        proficient_weapons=["longsword", "shortbow"],
+    )
+
+
+@pytest.fixture
+def goblin() -> Combatant:
+    """A typical goblin target."""
+    return Combatant(
+        name="Goblin",
+        ac=12,
+        abilities=Abilities(str=8, dex=14, con=10, int=10, wis=8, cha=8),
+        proficiency_bonus=2,
+        proficient_weapons=["scimitar"],
+    )
+
+
+@pytest.fixture
+def longsword() -> Weapon:
+    """Standard longsword."""
+    return Weapon(
+        name="Longsword",
+        damage_dice="1d8",
+        damage_type="slashing",
+        properties=[WeaponProperty.VERSATILE],
+    )
+
+
+@pytest.fixture
+def rapier() -> Weapon:
+    """Finesse weapon."""
+    return Weapon(
+        name="Rapier",
+        damage_dice="1d8",
+        damage_type="piercing",
+        properties=[WeaponProperty.FINESSE],
+    )
+
+
+@pytest.fixture
+def shortbow() -> Weapon:
+    """Ranged weapon."""
+    return Weapon(
+        name="Shortbow",
+        damage_dice="1d6",
+        damage_type="piercing",
+        properties=[WeaponProperty.RANGED],
+    )
+
+
+# --- Unit Tests ---
+
+
+class TestAbilityModifier:
+    """Tests for ability modifier calculation."""
+
+    def test_modifier_10_is_zero(self):
+        assert get_ability_modifier(10) == 0
+
+    def test_modifier_11_is_zero(self):
+        assert get_ability_modifier(11) == 0
+
+    def test_modifier_16_is_plus_3(self):
+        assert get_ability_modifier(16) == 3
+
+    def test_modifier_8_is_minus_1(self):
+        assert get_ability_modifier(8) == -1
+
+    def test_modifier_20_is_plus_5(self):
+        assert get_ability_modifier(20) == 5
+
+    def test_modifier_1_is_minus_5(self):
+        assert get_ability_modifier(1) == -5
+
+
+class TestCoverBonus:
+    """Tests for cover AC bonus."""
+
+    def test_no_cover(self):
+        assert get_cover_bonus(CoverType.NONE) == 0
+
+    def test_half_cover(self):
+        assert get_cover_bonus(CoverType.HALF) == 2
+
+    def test_three_quarters_cover(self):
+        assert get_cover_bonus(CoverType.THREE_QUARTERS) == 5
+
+    def test_total_cover(self):
+        # Should be effectively infinite
+        assert get_cover_bonus(CoverType.TOTAL) >= 50
+
+
+class TestAttackAbility:
+    """Tests for determining attack ability."""
+
+    def test_melee_uses_str(self, fighter: Combatant, longsword: Weapon):
+        assert get_attack_ability(longsword, fighter) == "str"
+
+    def test_ranged_uses_dex(self, fighter: Combatant, shortbow: Weapon):
+        assert get_attack_ability(shortbow, fighter) == "dex"
+
+    def test_finesse_uses_higher(self, rapier: Weapon):
+        # Fighter with higher STR
+        strong = Combatant(
+            name="Strong",
+            abilities=Abilities(str=16, dex=12),
+        )
+        assert get_attack_ability(rapier, strong) == "str"
+
+        # Rogue with higher DEX
+        agile = Combatant(
+            name="Agile",
+            abilities=Abilities(str=10, dex=16),
+        )
+        assert get_attack_ability(rapier, agile) == "dex"
+
+
+class TestResolveAttack:
+    """Tests for the resolve_attack function."""
+
+    def test_returns_attack_result(self, fighter: Combatant, goblin: Combatant, longsword: Weapon):
+        result = resolve_attack(fighter, goblin, longsword)
+        assert isinstance(result, AttackResult)
+
+    def test_natural_20_always_crits(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Natural 20 should always hit and be critical."""
+        mock_result = DiceResult(notation="1d20", rolls=[20], total=20)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        assert result.hit is True
+        assert result.critical is True
+        assert result.fumble is False
+        assert result.attack_roll == 20
+
+    def test_natural_1_always_fumbles(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Natural 1 should always miss."""
+        mock_result = DiceResult(notation="1d20", rolls=[1], total=1)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        assert result.hit is False
+        assert result.fumble is True
+        assert result.critical is False
+        assert result.damage is None
+
+    def test_hit_when_total_meets_ac(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Hit when total attack equals or exceeds AC."""
+        # Goblin AC 12, Fighter has +3 STR +2 prof = +5
+        # Roll 7 + 5 = 12, equals AC
+        mock_result = DiceResult(notation="1d20", rolls=[7], total=7)
+
+        def mock_roll(notation: str) -> DiceResult:
+            if "d20" in notation:
+                return mock_result
+            # Damage roll
+            return DiceResult(notation=notation, rolls=[4], total=4)
+
+        with patch("src.skills.combat.roll_dice", side_effect=mock_roll):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        assert result.hit is True
+        assert result.total_attack == 12  # 7 + 3 (STR) + 2 (prof)
+        assert result.damage is not None
+
+    def test_miss_when_total_below_ac(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Miss when total attack is below AC."""
+        # Roll 4 + 5 = 9, below AC 12
+        mock_result = DiceResult(notation="1d20", rolls=[4], total=4)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        assert result.hit is False
+        assert result.total_attack == 9
+        assert result.damage is None
+
+    def test_cover_increases_effective_ac(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Cover should add to target's effective AC."""
+        # Roll 9 + 5 = 14, hits AC 12 but not AC 14 (half cover)
+        mock_result = DiceResult(notation="1d20", rolls=[9], total=9)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, longsword, cover=CoverType.HALF)
+
+        assert result.target_ac == 14  # 12 + 2 (half cover)
+        assert result.hit is True  # 14 >= 14
+
+    def test_damage_includes_ability_modifier(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Damage should include ability modifier."""
+        mock_d20 = DiceResult(notation="1d20", rolls=[15], total=15)
+        mock_damage = DiceResult(notation="1d8", rolls=[4], total=4)
+
+        call_count = [0]
+
+        def mock_roll(notation: str) -> DiceResult:
+            if "d20" in notation:
+                return mock_d20
+            call_count[0] += 1
+            return mock_damage
+
+        with patch("src.skills.combat.roll_dice", side_effect=mock_roll):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        # 4 (dice) + 3 (STR mod) = 7
+        assert result.damage == 7
+        assert result.damage_type == "slashing"
+
+    def test_critical_doubles_damage_dice(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Critical hit should roll damage dice twice."""
+        mock_d20 = DiceResult(notation="1d20", rolls=[20], total=20)
+        mock_damage = DiceResult(notation="1d8", rolls=[4], total=4)
+
+        damage_rolls = []
+
+        def mock_roll(notation: str) -> DiceResult:
+            if "d20" in notation:
+                return mock_d20
+            damage_rolls.append(notation)
+            return mock_damage
+
+        with patch("src.skills.combat.roll_dice", side_effect=mock_roll):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        # Should roll damage twice for crit
+        assert len(damage_rolls) == 2
+        # 4 + 4 (doubled dice) + 3 (STR mod) = 11
+        assert result.damage == 11
+
+    def test_proficiency_applies_when_proficient(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Proficiency bonus should be added when proficient."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, longsword)
+
+        # 10 + 3 (STR) + 2 (prof) = 15
+        assert result.total_attack == 15
+
+    def test_no_proficiency_when_not_proficient(self, fighter: Combatant, goblin: Combatant):
+        """No proficiency bonus when not proficient with weapon."""
+        greataxe = Weapon(
+            name="Greataxe",
+            damage_dice="1d12",
+            damage_type="slashing",
+            properties=[WeaponProperty.HEAVY, WeaponProperty.TWO_HANDED],
+        )
+        # Fighter is not proficient with greataxe in our fixture
+
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        with patch("src.skills.combat.roll_dice", return_value=mock_result):
+            result = resolve_attack(fighter, goblin, greataxe)
+
+        # 10 + 3 (STR) + 0 (no prof) = 13
+        assert result.total_attack == 13
+
+    def test_minimum_damage_is_one(self, goblin: Combatant, longsword: Weapon):
+        """Minimum damage on hit should be 1."""
+        # Weak attacker with negative STR mod
+        weak = Combatant(
+            name="Weakling",
+            abilities=Abilities(str=4),  # -3 modifier
+            proficient_weapons=["longsword"],
+        )
+        target = Combatant(name="Target", ac=5)
+
+        mock_d20 = DiceResult(notation="1d20", rolls=[20], total=20)  # Crit to ensure hit
+        mock_damage = DiceResult(notation="1d8", rolls=[1], total=1)
+
+        def mock_roll(notation: str) -> DiceResult:
+            if "d20" in notation:
+                return mock_d20
+            return mock_damage
+
+        with patch("src.skills.combat.roll_dice", side_effect=mock_roll):
+            result = resolve_attack(weak, target, longsword)
+
+        # 1 + 1 (crit) - 3 (STR) = -1, but minimum 1
+        assert result.damage == 1
+
+
+class TestAdvantageDisadvantage:
+    """Tests for advantage and disadvantage."""
+
+    def test_advantage_rolls_2d20kh1(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Advantage should roll 2d20 keep highest."""
+        mock_result = DiceResult(notation="2d20kh1", rolls=[5, 15], kept=[15], total=15)
+
+        with patch("src.skills.combat.roll_dice", return_value=mock_result) as mock:
+            resolve_attack(fighter, goblin, longsword, advantage=True)
+
+        mock.assert_any_call("2d20kh1")
+
+    def test_disadvantage_rolls_2d20kl1(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Disadvantage should roll 2d20 keep lowest."""
+        mock_result = DiceResult(notation="2d20kl1", rolls=[5, 15], kept=[5], total=5)
+
+        with patch("src.skills.combat.roll_dice", return_value=mock_result) as mock:
+            resolve_attack(fighter, goblin, longsword, disadvantage=True)
+
+        mock.assert_any_call("2d20kl1")
+
+    def test_advantage_and_disadvantage_cancel(
+        self, fighter: Combatant, goblin: Combatant, longsword: Weapon
+    ):
+        """Advantage and disadvantage together should roll normally."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.combat.roll_dice", return_value=mock_result) as mock:
+            resolve_attack(fighter, goblin, longsword, advantage=True, disadvantage=True)
+
+        mock.assert_any_call("1d20")


### PR DESCRIPTION
## Summary
- Implements `resolve_attack()` per specs/mechanics.md Phase 2
- Full SRD 5e attack resolution with strict symbolic enforcement
- 27 new tests covering all rule edge cases

## SRD Rules Enforced
- Natural 20: always hits + critical (double damage dice)
- Natural 1: always misses (fumble)
- Ability modifiers (STR for melee, DEX for ranged)
- Finesse weapons use higher of STR/DEX
- Proficiency bonus when proficient
- Cover bonuses (+2 half, +5 three-quarters, total blocks)
- Advantage/disadvantage (2d20kh1 / 2d20kl1)
- Minimum 1 damage on hit

## New Models
- `Combatant` - attacker/target with AC, abilities, proficiencies
- `Weapon` - damage dice, type, properties
- `AttackResult` - hit/crit/fumble, damage, etc.
- `Abilities` - the six ability scores
- `CoverType` / `WeaponProperty` enums

## Test plan
- [x] 38 tests pass locally (27 new + 11 existing)
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] Pyright type check passes
- [ ] CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)