### PR TITLE
feat: add saving throws and skill checks per SRD 5e

### DIFF
--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -9,6 +9,15 @@ Skills are pure functions that:
 - NEVER call LLMs directly
 """
 
+from src.skills.checks import (
+    SKILL_ABILITIES,
+    CheckResult,
+    SaveResult,
+    SkillProficiencies,
+    ability_check,
+    make_saving_throw,
+    skill_check,
+)
 from src.skills.combat import (
     Abilities,
     AttackResult,
@@ -22,8 +31,10 @@ from src.skills.combat import (
 from src.skills.dice import DiceResult, roll_dice
 
 __all__ = [
+    # Dice
     "roll_dice",
     "DiceResult",
+    # Combat
     "resolve_attack",
     "AttackResult",
     "Combatant",
@@ -32,4 +43,12 @@ __all__ = [
     "Abilities",
     "CoverType",
     "get_ability_modifier",
+    # Checks & Saves
+    "make_saving_throw",
+    "SaveResult",
+    "skill_check",
+    "ability_check",
+    "CheckResult",
+    "SkillProficiencies",
+    "SKILL_ABILITIES",
 ]

--- a/src/skills/checks.py
+++ b/src/skills/checks.py
@@ -1,0 +1,270 @@
+"""
+Saving Throws and Skill Checks.
+
+Implements SRD 5e saving throws and ability/skill checks.
+The Symbolic layer - strict DC resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.skills.combat import Abilities, Combatant, get_ability_modifier
+from src.skills.dice import roll_dice
+
+# SRD 5e skill to ability mappings
+SKILL_ABILITIES: dict[str, Literal["str", "dex", "con", "int", "wis", "cha"]] = {
+    # Strength
+    "athletics": "str",
+    # Dexterity
+    "acrobatics": "dex",
+    "sleight_of_hand": "dex",
+    "stealth": "dex",
+    # Intelligence
+    "arcana": "int",
+    "history": "int",
+    "investigation": "int",
+    "nature": "int",
+    "religion": "int",
+    # Wisdom
+    "animal_handling": "wis",
+    "insight": "wis",
+    "medicine": "wis",
+    "perception": "wis",
+    "survival": "wis",
+    # Charisma
+    "deception": "cha",
+    "intimidation": "cha",
+    "performance": "cha",
+    "persuasion": "cha",
+}
+
+
+class SaveResult(BaseModel):
+    """Result of a saving throw."""
+
+    success: bool
+    roll: int = Field(description="The natural d20 result")
+    total: int = Field(description="Roll + modifier")
+    dc: int = Field(description="Difficulty class to beat")
+    margin: int = Field(description="How much over/under DC (positive = success margin)")
+    ability: str = Field(description="The ability used")
+
+
+class CheckResult(BaseModel):
+    """Result of an ability or skill check."""
+
+    success: bool
+    roll: int = Field(description="The natural d20 result")
+    total: int = Field(description="Roll + modifiers")
+    dc: int = Field(description="Difficulty class to beat")
+    margin: int = Field(description="How much over/under DC")
+    skill: str | None = Field(default=None, description="Skill used, if any")
+    ability: str = Field(description="The ability used")
+
+
+class SkillProficiencies(BaseModel):
+    """Skill proficiency configuration for a character."""
+
+    proficient: list[str] = Field(default_factory=list)
+    expertise: list[str] = Field(default_factory=list)  # Double proficiency
+
+
+def get_ability_score(abilities: Abilities, ability: str) -> int:
+    """Get ability score by name."""
+    match ability:
+        case "str":
+            return abilities.str_
+        case "dex":
+            return abilities.dex
+        case "con":
+            return abilities.con
+        case "int":
+            return abilities.int_
+        case "wis":
+            return abilities.wis
+        case "cha":
+            return abilities.cha
+        case _:
+            raise ValueError(f"Unknown ability: {ability}")
+
+
+def make_saving_throw(
+    entity: Combatant,
+    ability: Literal["str", "dex", "con", "int", "wis", "cha"],
+    dc: int,
+    advantage: bool = False,
+    disadvantage: bool = False,
+    proficient: bool = False,
+) -> SaveResult:
+    """
+    Make a saving throw against a DC.
+
+    Args:
+        entity: The one making the save
+        ability: Which ability to use
+        dc: Difficulty class to beat
+        advantage: Roll 2d20 take highest
+        disadvantage: Roll 2d20 take lowest
+        proficient: Whether entity is proficient in this save
+
+    Returns:
+        SaveResult with success/failure and margin
+
+    SRD Rules:
+        - Roll d20 + ability modifier
+        - Add proficiency bonus if proficient in that save
+        - Meet or exceed DC to succeed
+    """
+    # Determine roll type
+    if advantage and not disadvantage:
+        roll_result = roll_dice("2d20kh1")
+    elif disadvantage and not advantage:
+        roll_result = roll_dice("2d20kl1")
+    else:
+        roll_result = roll_dice("1d20")
+
+    natural_roll = roll_result.kept[0] if roll_result.kept else roll_result.rolls[0]
+
+    # Get ability modifier
+    ability_score = get_ability_score(entity.abilities, ability)
+    ability_mod = get_ability_modifier(ability_score)
+
+    # Add proficiency if applicable
+    prof_bonus = entity.proficiency_bonus if proficient else 0
+
+    total = natural_roll + ability_mod + prof_bonus
+    margin = total - dc
+    success = total >= dc
+
+    return SaveResult(
+        success=success,
+        roll=natural_roll,
+        total=total,
+        dc=dc,
+        margin=margin,
+        ability=ability,
+    )
+
+
+def skill_check(
+    entity: Combatant,
+    skill: str,
+    dc: int,
+    skill_proficiencies: SkillProficiencies | None = None,
+    advantage: bool = False,
+    disadvantage: bool = False,
+) -> CheckResult:
+    """
+    Make a skill check against a DC.
+
+    Args:
+        entity: The one making the check
+        skill: The skill to use (must be in SKILL_ABILITIES)
+        dc: Difficulty class to beat
+        skill_proficiencies: Proficiency/expertise in skills
+        advantage: Roll 2d20 take highest
+        disadvantage: Roll 2d20 take lowest
+
+    Returns:
+        CheckResult with success/failure and margin
+
+    SRD Rules:
+        - Roll d20 + ability modifier (based on skill)
+        - Add proficiency bonus if proficient
+        - Add double proficiency if expertise
+        - Meet or exceed DC to succeed
+    """
+    skill_lower = skill.lower().replace(" ", "_")
+
+    if skill_lower not in SKILL_ABILITIES:
+        raise ValueError(f"Unknown skill: {skill}. Valid skills: {list(SKILL_ABILITIES.keys())}")
+
+    ability = SKILL_ABILITIES[skill_lower]
+
+    # Determine roll type
+    if advantage and not disadvantage:
+        roll_result = roll_dice("2d20kh1")
+    elif disadvantage and not advantage:
+        roll_result = roll_dice("2d20kl1")
+    else:
+        roll_result = roll_dice("1d20")
+
+    natural_roll = roll_result.kept[0] if roll_result.kept else roll_result.rolls[0]
+
+    # Get ability modifier
+    ability_score = get_ability_score(entity.abilities, ability)
+    ability_mod = get_ability_modifier(ability_score)
+
+    # Proficiency bonus
+    prof_bonus = 0
+    if skill_proficiencies:
+        if skill_lower in skill_proficiencies.expertise:
+            prof_bonus = entity.proficiency_bonus * 2  # Expertise
+        elif skill_lower in skill_proficiencies.proficient:
+            prof_bonus = entity.proficiency_bonus
+
+    total = natural_roll + ability_mod + prof_bonus
+    margin = total - dc
+    success = total >= dc
+
+    return CheckResult(
+        success=success,
+        roll=natural_roll,
+        total=total,
+        dc=dc,
+        margin=margin,
+        skill=skill_lower,
+        ability=ability,
+    )
+
+
+def ability_check(
+    entity: Combatant,
+    ability: Literal["str", "dex", "con", "int", "wis", "cha"],
+    dc: int,
+    advantage: bool = False,
+    disadvantage: bool = False,
+) -> CheckResult:
+    """
+    Make a raw ability check (no skill) against a DC.
+
+    Args:
+        entity: The one making the check
+        ability: Which ability to use
+        dc: Difficulty class to beat
+        advantage: Roll 2d20 take highest
+        disadvantage: Roll 2d20 take lowest
+
+    Returns:
+        CheckResult with success/failure and margin
+    """
+    # Determine roll type
+    if advantage and not disadvantage:
+        roll_result = roll_dice("2d20kh1")
+    elif disadvantage and not advantage:
+        roll_result = roll_dice("2d20kl1")
+    else:
+        roll_result = roll_dice("1d20")
+
+    natural_roll = roll_result.kept[0] if roll_result.kept else roll_result.rolls[0]
+
+    # Get ability modifier
+    ability_score = get_ability_score(entity.abilities, ability)
+    ability_mod = get_ability_modifier(ability_score)
+
+    total = natural_roll + ability_mod
+    margin = total - dc
+    success = total >= dc
+
+    return CheckResult(
+        success=success,
+        roll=natural_roll,
+        total=total,
+        dc=dc,
+        margin=margin,
+        skill=None,
+        ability=ability,
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,330 @@
+"""Tests for saving throws and skill checks."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.skills.checks import (
+    SKILL_ABILITIES,
+    CheckResult,
+    SaveResult,
+    SkillProficiencies,
+    ability_check,
+    get_ability_score,
+    make_saving_throw,
+    skill_check,
+)
+from src.skills.combat import Abilities, Combatant
+from src.skills.dice import DiceResult
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def fighter() -> Combatant:
+    """A typical fighter with varied abilities."""
+    return Combatant(
+        name="Fighter",
+        ac=16,
+        abilities=Abilities(str=16, dex=12, con=14, int=10, wis=10, cha=8),
+        proficiency_bonus=2,
+    )
+
+
+@pytest.fixture
+def rogue() -> Combatant:
+    """A typical rogue with high DEX."""
+    return Combatant(
+        name="Rogue",
+        ac=14,
+        abilities=Abilities(str=10, dex=18, con=12, int=14, wis=12, cha=14),
+        proficiency_bonus=3,
+    )
+
+
+# --- Unit Tests ---
+
+
+class TestGetAbilityScore:
+    """Tests for ability score lookup."""
+
+    def test_get_str(self):
+        abilities = Abilities(str=16, dex=12, con=14, int=10, wis=10, cha=8)
+        assert get_ability_score(abilities, "str") == 16
+
+    def test_get_dex(self):
+        abilities = Abilities(str=10, dex=18)
+        assert get_ability_score(abilities, "dex") == 18
+
+    def test_get_con(self):
+        abilities = Abilities(con=14)
+        assert get_ability_score(abilities, "con") == 14
+
+    def test_get_int(self):
+        abilities = Abilities(int=12)
+        assert get_ability_score(abilities, "int") == 12
+
+    def test_get_wis(self):
+        abilities = Abilities(wis=16)
+        assert get_ability_score(abilities, "wis") == 16
+
+    def test_get_cha(self):
+        abilities = Abilities(cha=14)
+        assert get_ability_score(abilities, "cha") == 14
+
+    def test_invalid_ability_raises(self):
+        abilities = Abilities()
+        with pytest.raises(ValueError, match="Unknown ability"):
+            get_ability_score(abilities, "luck")
+
+
+class TestMakeSavingThrow:
+    """Tests for saving throw resolution."""
+
+    def test_returns_save_result(self, fighter: Combatant):
+        result = make_saving_throw(fighter, "str", dc=15)
+        assert isinstance(result, SaveResult)
+
+    def test_success_when_total_meets_dc(self, fighter: Combatant):
+        """Meeting DC exactly is a success."""
+        # DC 15, STR mod +3, need to roll 12
+        mock_result = DiceResult(notation="1d20", rolls=[12], total=12)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = make_saving_throw(fighter, "str", dc=15)
+
+        assert result.success is True
+        assert result.total == 15  # 12 + 3
+        assert result.margin == 0
+
+    def test_success_when_total_exceeds_dc(self, fighter: Combatant):
+        mock_result = DiceResult(notation="1d20", rolls=[15], total=15)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = make_saving_throw(fighter, "str", dc=15)
+
+        assert result.success is True
+        assert result.total == 18  # 15 + 3
+        assert result.margin == 3
+
+    def test_failure_when_total_below_dc(self, fighter: Combatant):
+        mock_result = DiceResult(notation="1d20", rolls=[5], total=5)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = make_saving_throw(fighter, "str", dc=15)
+
+        assert result.success is False
+        assert result.total == 8  # 5 + 3
+        assert result.margin == -7
+
+    def test_proficiency_adds_bonus(self, fighter: Combatant):
+        """Proficiency in save adds proficiency bonus."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = make_saving_throw(fighter, "str", dc=15, proficient=True)
+
+        # 10 + 3 (STR) + 2 (prof) = 15
+        assert result.total == 15
+        assert result.success is True
+
+    def test_uses_correct_ability_modifier(self, fighter: Combatant):
+        """Each ability uses its own modifier."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # STR 16 = +3
+            str_save = make_saving_throw(fighter, "str", dc=15)
+            assert str_save.total == 13
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # DEX 12 = +1
+            dex_save = make_saving_throw(fighter, "dex", dc=15)
+            assert dex_save.total == 11
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # CHA 8 = -1
+            cha_save = make_saving_throw(fighter, "cha", dc=15)
+            assert cha_save.total == 9
+
+    def test_advantage_rolls_2d20kh1(self, fighter: Combatant):
+        mock_result = DiceResult(notation="2d20kh1", rolls=[5, 15], kept=[15], total=15)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result) as mock:
+            make_saving_throw(fighter, "dex", dc=15, advantage=True)
+
+        mock.assert_called_with("2d20kh1")
+
+    def test_disadvantage_rolls_2d20kl1(self, fighter: Combatant):
+        mock_result = DiceResult(notation="2d20kl1", rolls=[5, 15], kept=[5], total=5)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result) as mock:
+            make_saving_throw(fighter, "dex", dc=15, disadvantage=True)
+
+        mock.assert_called_with("2d20kl1")
+
+    def test_advantage_and_disadvantage_cancel(self, fighter: Combatant):
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        with patch("src.skills.checks.roll_dice", return_value=mock_result) as mock:
+            make_saving_throw(fighter, "dex", dc=15, advantage=True, disadvantage=True)
+
+        mock.assert_called_with("1d20")
+
+
+class TestSkillCheck:
+    """Tests for skill check resolution."""
+
+    def test_returns_check_result(self, rogue: Combatant):
+        result = skill_check(rogue, "stealth", dc=15)
+        assert isinstance(result, CheckResult)
+
+    def test_uses_correct_ability_for_skill(self, rogue: Combatant):
+        """Skills use their mapped ability."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # Stealth uses DEX (18 = +4)
+            stealth = skill_check(rogue, "stealth", dc=15)
+            assert stealth.total == 14
+            assert stealth.ability == "dex"
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # Investigation uses INT (14 = +2)
+            investigation = skill_check(rogue, "investigation", dc=15)
+            assert investigation.total == 12
+            assert investigation.ability == "int"
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            # Persuasion uses CHA (14 = +2)
+            persuasion = skill_check(rogue, "persuasion", dc=15)
+            assert persuasion.total == 12
+            assert persuasion.ability == "cha"
+
+    def test_proficiency_adds_bonus(self, rogue: Combatant):
+        """Proficiency in skill adds proficiency bonus."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        profs = SkillProficiencies(proficient=["stealth"])
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = skill_check(rogue, "stealth", dc=15, skill_proficiencies=profs)
+
+        # 10 + 4 (DEX) + 3 (prof) = 17
+        assert result.total == 17
+        assert result.success is True
+
+    def test_expertise_doubles_proficiency(self, rogue: Combatant):
+        """Expertise adds double proficiency bonus."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        profs = SkillProficiencies(expertise=["stealth"])
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = skill_check(rogue, "stealth", dc=15, skill_proficiencies=profs)
+
+        # 10 + 4 (DEX) + 6 (expertise = 2x prof) = 20
+        assert result.total == 20
+
+    def test_expertise_overrides_proficiency(self, rogue: Combatant):
+        """If skill is in both, expertise takes precedence."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+        profs = SkillProficiencies(proficient=["stealth"], expertise=["stealth"])
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = skill_check(rogue, "stealth", dc=15, skill_proficiencies=profs)
+
+        # Should use expertise (double), not proficiency
+        assert result.total == 20
+
+    def test_unknown_skill_raises(self, rogue: Combatant):
+        with pytest.raises(ValueError, match="Unknown skill"):
+            skill_check(rogue, "hacking", dc=15)
+
+    def test_skill_name_case_insensitive(self, rogue: Combatant):
+        """Skill names should be case insensitive."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result1 = skill_check(rogue, "Stealth", dc=15)
+            assert result1.skill == "stealth"
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result2 = skill_check(rogue, "PERCEPTION", dc=15)
+            assert result2.skill == "perception"
+
+    def test_skill_name_with_spaces(self, rogue: Combatant):
+        """Skills with spaces should work."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = skill_check(rogue, "sleight of hand", dc=15)
+            assert result.skill == "sleight_of_hand"
+            assert result.ability == "dex"
+
+    def test_margin_calculation(self, rogue: Combatant):
+        """Margin should be total - DC."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = skill_check(rogue, "stealth", dc=12)
+
+        # Total 14, DC 12, margin = 2
+        assert result.margin == 2
+        assert result.success is True
+
+    def test_advantage_and_disadvantage(self, rogue: Combatant):
+        """Advantage and disadvantage work for skill checks."""
+        mock_adv = DiceResult(notation="2d20kh1", rolls=[5, 18], kept=[18], total=18)
+        with patch("src.skills.checks.roll_dice", return_value=mock_adv) as mock:
+            skill_check(rogue, "stealth", dc=15, advantage=True)
+        mock.assert_called_with("2d20kh1")
+
+        mock_dis = DiceResult(notation="2d20kl1", rolls=[5, 18], kept=[5], total=5)
+        with patch("src.skills.checks.roll_dice", return_value=mock_dis) as mock:
+            skill_check(rogue, "stealth", dc=15, disadvantage=True)
+        mock.assert_called_with("2d20kl1")
+
+
+class TestAbilityCheck:
+    """Tests for raw ability checks."""
+
+    def test_returns_check_result(self, fighter: Combatant):
+        result = ability_check(fighter, "str", dc=15)
+        assert isinstance(result, CheckResult)
+        assert result.skill is None  # No skill for raw ability check
+
+    def test_uses_correct_modifier(self, fighter: Combatant):
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = ability_check(fighter, "str", dc=15)
+
+        # STR 16 = +3, so total = 13
+        assert result.total == 13
+        assert result.ability == "str"
+
+    def test_no_proficiency_on_ability_checks(self, fighter: Combatant):
+        """Raw ability checks don't include proficiency."""
+        mock_result = DiceResult(notation="1d20", rolls=[10], total=10)
+
+        with patch("src.skills.checks.roll_dice", return_value=mock_result):
+            result = ability_check(fighter, "str", dc=15)
+
+        # Just 10 + 3 (mod), no proficiency
+        assert result.total == 13
+
+
+class TestSkillAbilitiesMapping:
+    """Tests for the SKILL_ABILITIES constant."""
+
+    def test_all_skills_have_valid_abilities(self):
+        valid_abilities = {"str", "dex", "con", "int", "wis", "cha"}
+        for skill, ability in SKILL_ABILITIES.items():
+            assert ability in valid_abilities, f"{skill} has invalid ability {ability}"
+
+    def test_expected_skills_present(self):
+        expected = [
+            "athletics",
+            "acrobatics",
+            "stealth",
+            "arcana",
+            "perception",
+            "persuasion",
+            "intimidation",
+        ]
+        for skill in expected:
+            assert skill in SKILL_ABILITIES


### PR DESCRIPTION
## Summary
- Implements Phase 3 of specs/mechanics.md
- Saving throws, skill checks, and raw ability checks
- 31 new tests (69 total)

## Functions Added

| Function | Description |
|----------|-------------|
| `make_saving_throw()` | d20 + ability mod + prof vs DC |
| `skill_check()` | d20 + ability mod + skill prof vs DC |
| `ability_check()` | d20 + ability mod vs DC (no skill) |

## SRD Compliance
- All 18 skills mapped to correct abilities
- Expertise (double proficiency) support
- Advantage/disadvantage on all check types
- Margin calculation (success by how much)

## New Models
- `SaveResult` - saving throw outcome
- `CheckResult` - skill/ability check outcome  
- `SkillProficiencies` - proficiency + expertise lists
- `SKILL_ABILITIES` - constant mapping skills → abilities

## Test plan
- [x] 69 tests pass locally
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] Pyright type check passes
- [ ] CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)