### PR TITLE
feat: add rest and recovery mechanics per SRD 5e

### DIFF
--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -43,6 +43,16 @@ from src.skills.economy import (
     execute_purchase,
     execute_sale,
 )
+from src.skills.rest import (
+    CharacterResources,
+    HitDice,
+    LongRestResult,
+    ShortRestResult,
+    SpellSlots,
+    spend_hit_die,
+    take_long_rest,
+    take_short_rest,
+)
 
 __all__ = [
     # Dice
@@ -78,4 +88,13 @@ __all__ = [
     "calculate_buy_price",
     "calculate_sell_price",
     "convert_currency",
+    # Rest & Recovery
+    "CharacterResources",
+    "HitDice",
+    "SpellSlots",
+    "ShortRestResult",
+    "LongRestResult",
+    "take_short_rest",
+    "take_long_rest",
+    "spend_hit_die",
 ]

--- a/src/skills/rest.py
+++ b/src/skills/rest.py
@@ -1,0 +1,320 @@
+"""
+Rest and Recovery Skills.
+
+Implements SRD 5e short rest and long rest mechanics.
+Handles HP recovery, hit dice, and spell slot restoration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from src.skills.dice import roll_dice
+
+
+class HitDice(BaseModel):
+    """
+    Hit dice pool for a character.
+
+    Hit dice are used during short rests to recover HP.
+    """
+
+    die_type: str = Field(description="Die size, e.g., 'd8', 'd10'")
+    total: int = Field(ge=1, description="Maximum hit dice (usually = level)")
+    current: int = Field(ge=0, description="Available hit dice to spend")
+
+    @model_validator(mode="after")
+    def current_not_exceeds_total(self) -> HitDice:
+        if self.current > self.total:
+            self.current = self.total
+        return self
+
+    def spend(self, count: int = 1) -> int:
+        """
+        Spend hit dice and return how many were actually spent.
+
+        Returns the actual number spent (may be less if not enough available).
+        """
+        actual = min(count, self.current)
+        self.current -= actual
+        return actual
+
+    def recover(self, count: int) -> int:
+        """
+        Recover hit dice (typically during long rest).
+
+        Returns the actual number recovered.
+        """
+        space = self.total - self.current
+        actual = min(count, space)
+        self.current += actual
+        return actual
+
+
+class SpellSlots(BaseModel):
+    """
+    Spell slot tracking for a spellcaster.
+
+    Keys are slot levels (1-9), values are [current, maximum].
+    """
+
+    slots: dict[int, tuple[int, int]] = Field(
+        default_factory=dict,
+        description="Slot level -> (current, max)",
+    )
+
+    def get_available(self, level: int) -> int:
+        """Get available slots at a given level."""
+        if level not in self.slots:
+            return 0
+        return self.slots[level][0]
+
+    def get_maximum(self, level: int) -> int:
+        """Get maximum slots at a given level."""
+        if level not in self.slots:
+            return 0
+        return self.slots[level][1]
+
+    def use_slot(self, level: int) -> bool:
+        """
+        Use a spell slot of the given level.
+
+        Returns True if successful, False if no slots available.
+        """
+        if level not in self.slots:
+            return False
+        current, maximum = self.slots[level]
+        if current <= 0:
+            return False
+        self.slots[level] = (current - 1, maximum)
+        return True
+
+    def restore_all(self) -> dict[int, int]:
+        """
+        Restore all spell slots to maximum (long rest).
+
+        Returns dict of level -> slots restored.
+        """
+        restored = {}
+        for level, (current, maximum) in self.slots.items():
+            if current < maximum:
+                restored[level] = maximum - current
+                self.slots[level] = (maximum, maximum)
+        return restored
+
+    def restore_slot(self, level: int, count: int = 1) -> int:
+        """
+        Restore specific slots (for abilities like Arcane Recovery).
+
+        Returns actual number restored.
+        """
+        if level not in self.slots:
+            return 0
+        current, maximum = self.slots[level]
+        space = maximum - current
+        actual = min(count, space)
+        self.slots[level] = (current + actual, maximum)
+        return actual
+
+
+class CharacterResources(BaseModel):
+    """
+    Trackable resources for a character.
+
+    This is a lightweight model for rest mechanics - not the full Entity.
+    """
+
+    hp_current: int = Field(ge=0, description="Current hit points")
+    hp_max: int = Field(ge=1, description="Maximum hit points")
+    hp_temp: int = Field(default=0, ge=0, description="Temporary hit points")
+    con_modifier: int = Field(default=0, description="Constitution modifier for hit dice")
+    hit_dice: HitDice
+    spell_slots: SpellSlots | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def hp_not_exceeds_max(self) -> CharacterResources:
+        if self.hp_current > self.hp_max:
+            self.hp_current = self.hp_max
+        return self
+
+    def heal(self, amount: int) -> int:
+        """
+        Heal HP up to maximum.
+
+        Returns actual HP healed.
+        """
+        space = self.hp_max - self.hp_current
+        actual = min(amount, space)
+        self.hp_current += actual
+        return actual
+
+    def take_damage(self, amount: int) -> int:
+        """
+        Take damage, consuming temp HP first.
+
+        Returns actual HP lost (after temp HP absorbed).
+        """
+        # Temp HP absorbs first
+        if self.hp_temp > 0:
+            if amount <= self.hp_temp:
+                self.hp_temp -= amount
+                return 0
+            else:
+                amount -= self.hp_temp
+                self.hp_temp = 0
+
+        # Remaining damage to HP
+        actual = min(amount, self.hp_current)
+        self.hp_current -= actual
+        return actual
+
+
+class ShortRestResult(BaseModel):
+    """Result of taking a short rest."""
+
+    hit_dice_spent: int
+    hit_dice_remaining: int
+    hp_healed: int
+    hp_current: int
+    hp_max: int
+    rolls: list[int] = Field(default_factory=list, description="Individual hit die rolls")
+
+
+class LongRestResult(BaseModel):
+    """Result of taking a long rest."""
+
+    hp_healed: int
+    hp_current: int
+    hp_max: int
+    hit_dice_recovered: int
+    hit_dice_current: int
+    hit_dice_max: int
+    spell_slots_restored: dict[int, int] = Field(
+        default_factory=dict, description="Slots restored per level"
+    )
+
+
+def take_short_rest(
+    character: CharacterResources,
+    hit_dice_to_spend: int = 0,
+) -> ShortRestResult:
+    """
+    Take a short rest (1 hour).
+
+    During a short rest, a character can spend hit dice to recover HP.
+    Each hit die rolled + CON modifier = HP healed.
+
+    Args:
+        character: The character's resources
+        hit_dice_to_spend: Number of hit dice to spend (0 = rest without healing)
+
+    Returns:
+        ShortRestResult with healing details
+
+    SRD Rules:
+        - Can spend any number of available hit dice
+        - Each die: roll + CON modifier (minimum 0 HP per die)
+        - Temp HP remains unchanged
+    """
+    dice_spent = 0
+    total_healed = 0
+    rolls = []
+
+    for _ in range(hit_dice_to_spend):
+        if character.hit_dice.current <= 0:
+            break
+
+        character.hit_dice.spend(1)
+        dice_spent += 1
+
+        # Roll the hit die
+        roll_result = roll_dice(f"1{character.hit_dice.die_type}")
+        roll_value = roll_result.total
+
+        # Add CON modifier, minimum 1 HP per die spent
+        hp_from_die = max(1, roll_value + character.con_modifier)
+        rolls.append(roll_value)
+
+        # Heal
+        actual_healed = character.heal(hp_from_die)
+        total_healed += actual_healed
+
+        # Stop if at max HP
+        if character.hp_current >= character.hp_max:
+            break
+
+    return ShortRestResult(
+        hit_dice_spent=dice_spent,
+        hit_dice_remaining=character.hit_dice.current,
+        hp_healed=total_healed,
+        hp_current=character.hp_current,
+        hp_max=character.hp_max,
+        rolls=rolls,
+    )
+
+
+def take_long_rest(character: CharacterResources) -> LongRestResult:
+    """
+    Take a long rest (8 hours).
+
+    A long rest fully restores HP, recovers half of max hit dice,
+    and restores all spell slots.
+
+    Args:
+        character: The character's resources
+
+    Returns:
+        LongRestResult with recovery details
+
+    SRD Rules:
+        - Regain all lost HP
+        - Regain half of total hit dice (minimum 1)
+        - Regain all expended spell slots
+        - Temp HP remains unchanged
+    """
+    # Heal to full
+    hp_healed = character.hp_max - character.hp_current
+    character.hp_current = character.hp_max
+
+    # Recover half of max hit dice (minimum 1)
+    dice_to_recover = max(1, character.hit_dice.total // 2)
+    dice_recovered = character.hit_dice.recover(dice_to_recover)
+
+    # Restore spell slots
+    slots_restored: dict[int, int] = {}
+    if character.spell_slots:
+        slots_restored = character.spell_slots.restore_all()
+
+    return LongRestResult(
+        hp_healed=hp_healed,
+        hp_current=character.hp_current,
+        hp_max=character.hp_max,
+        hit_dice_recovered=dice_recovered,
+        hit_dice_current=character.hit_dice.current,
+        hit_dice_max=character.hit_dice.total,
+        spell_slots_restored=slots_restored,
+    )
+
+
+def spend_hit_die(
+    character: CharacterResources,
+) -> tuple[int, int] | None:
+    """
+    Spend a single hit die and return (roll, hp_healed).
+
+    Convenience function for spending one hit die at a time.
+
+    Returns:
+        Tuple of (die_roll, actual_hp_healed) or None if no dice available
+    """
+    if character.hit_dice.current <= 0:
+        return None
+
+    character.hit_dice.spend(1)
+    roll_result = roll_dice(f"1{character.hit_dice.die_type}")
+    roll_value = roll_result.total
+
+    hp_from_die = max(1, roll_value + character.con_modifier)
+    actual_healed = character.heal(hp_from_die)
+
+    return (roll_value, actual_healed)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,449 @@
+"""Tests for rest and recovery skills."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.skills.dice import DiceResult
+from src.skills.rest import (
+    CharacterResources,
+    HitDice,
+    LongRestResult,
+    ShortRestResult,
+    SpellSlots,
+    spend_hit_die,
+    take_long_rest,
+    take_short_rest,
+)
+
+# --- HitDice Tests ---
+
+
+class TestHitDice:
+    """Tests for HitDice model."""
+
+    def test_creation(self):
+        hd = HitDice(die_type="d8", total=5, current=5)
+        assert hd.die_type == "d8"
+        assert hd.total == 5
+        assert hd.current == 5
+
+    def test_current_capped_at_total(self):
+        """Current should not exceed total."""
+        hd = HitDice(die_type="d8", total=5, current=10)
+        assert hd.current == 5
+
+    def test_spend_single(self):
+        hd = HitDice(die_type="d8", total=5, current=5)
+        spent = hd.spend(1)
+        assert spent == 1
+        assert hd.current == 4
+
+    def test_spend_multiple(self):
+        hd = HitDice(die_type="d10", total=5, current=5)
+        spent = hd.spend(3)
+        assert spent == 3
+        assert hd.current == 2
+
+    def test_spend_more_than_available(self):
+        hd = HitDice(die_type="d8", total=5, current=2)
+        spent = hd.spend(5)
+        assert spent == 2  # Only had 2
+        assert hd.current == 0
+
+    def test_spend_when_empty(self):
+        hd = HitDice(die_type="d8", total=5, current=0)
+        spent = hd.spend(1)
+        assert spent == 0
+        assert hd.current == 0
+
+    def test_recover(self):
+        hd = HitDice(die_type="d8", total=5, current=2)
+        recovered = hd.recover(2)
+        assert recovered == 2
+        assert hd.current == 4
+
+    def test_recover_capped_at_total(self):
+        hd = HitDice(die_type="d8", total=5, current=4)
+        recovered = hd.recover(5)
+        assert recovered == 1  # Only room for 1
+        assert hd.current == 5
+
+
+# --- SpellSlots Tests ---
+
+
+class TestSpellSlots:
+    """Tests for SpellSlots model."""
+
+    def test_empty_slots(self):
+        ss = SpellSlots()
+        assert ss.get_available(1) == 0
+        assert ss.get_maximum(1) == 0
+
+    def test_get_available(self):
+        ss = SpellSlots(slots={1: (4, 4), 2: (2, 3)})
+        assert ss.get_available(1) == 4
+        assert ss.get_available(2) == 2
+        assert ss.get_available(3) == 0
+
+    def test_get_maximum(self):
+        ss = SpellSlots(slots={1: (2, 4), 2: (1, 3)})
+        assert ss.get_maximum(1) == 4
+        assert ss.get_maximum(2) == 3
+
+    def test_use_slot_success(self):
+        ss = SpellSlots(slots={1: (4, 4)})
+        result = ss.use_slot(1)
+        assert result is True
+        assert ss.get_available(1) == 3
+
+    def test_use_slot_empty(self):
+        ss = SpellSlots(slots={1: (0, 4)})
+        result = ss.use_slot(1)
+        assert result is False
+        assert ss.get_available(1) == 0
+
+    def test_use_slot_invalid_level(self):
+        ss = SpellSlots(slots={1: (4, 4)})
+        result = ss.use_slot(5)
+        assert result is False
+
+    def test_restore_all(self):
+        ss = SpellSlots(slots={1: (1, 4), 2: (0, 3), 3: (2, 2)})
+        restored = ss.restore_all()
+
+        assert restored == {1: 3, 2: 3}  # Level 3 was already full
+        assert ss.get_available(1) == 4
+        assert ss.get_available(2) == 3
+        assert ss.get_available(3) == 2
+
+    def test_restore_slot(self):
+        ss = SpellSlots(slots={1: (1, 4)})
+        actual = ss.restore_slot(1, 2)
+        assert actual == 2
+        assert ss.get_available(1) == 3
+
+
+# --- CharacterResources Tests ---
+
+
+class TestCharacterResources:
+    """Tests for CharacterResources model."""
+
+    def test_creation(self):
+        char = CharacterResources(
+            hp_current=30,
+            hp_max=40,
+            con_modifier=2,
+            hit_dice=HitDice(die_type="d10", total=5, current=5),
+        )
+        assert char.hp_current == 30
+        assert char.hp_max == 40
+
+    def test_hp_capped_at_max(self):
+        char = CharacterResources(
+            hp_current=50,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        assert char.hp_current == 40
+
+    def test_heal(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        healed = char.heal(15)
+        assert healed == 15
+        assert char.hp_current == 35
+
+    def test_heal_capped(self):
+        char = CharacterResources(
+            hp_current=35,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        healed = char.heal(10)
+        assert healed == 5
+        assert char.hp_current == 40
+
+    def test_take_damage(self):
+        char = CharacterResources(
+            hp_current=30,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        lost = char.take_damage(10)
+        assert lost == 10
+        assert char.hp_current == 20
+
+    def test_take_damage_with_temp_hp(self):
+        char = CharacterResources(
+            hp_current=30,
+            hp_max=40,
+            hp_temp=10,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        lost = char.take_damage(15)
+        assert lost == 5  # 10 absorbed by temp, 5 actual
+        assert char.hp_temp == 0
+        assert char.hp_current == 25
+
+    def test_temp_hp_absorbs_all(self):
+        char = CharacterResources(
+            hp_current=30,
+            hp_max=40,
+            hp_temp=20,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        lost = char.take_damage(15)
+        assert lost == 0
+        assert char.hp_temp == 5
+        assert char.hp_current == 30
+
+
+# --- Short Rest Tests ---
+
+
+class TestTakeShortRest:
+    """Tests for take_short_rest function."""
+
+    def test_rest_without_spending_dice(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        result = take_short_rest(char, hit_dice_to_spend=0)
+
+        assert isinstance(result, ShortRestResult)
+        assert result.hit_dice_spent == 0
+        assert result.hp_healed == 0
+        assert result.hit_dice_remaining == 5
+
+    def test_spend_one_hit_die(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            con_modifier=2,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+
+        mock_roll = DiceResult(notation="1d8", rolls=[5], total=5)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = take_short_rest(char, hit_dice_to_spend=1)
+
+        assert result.hit_dice_spent == 1
+        assert result.hit_dice_remaining == 4
+        # Healed = 5 (roll) + 2 (CON) = 7
+        assert result.hp_healed == 7
+        assert result.hp_current == 27
+        assert result.rolls == [5]
+
+    def test_spend_multiple_hit_dice(self):
+        char = CharacterResources(
+            hp_current=10,
+            hp_max=40,
+            con_modifier=1,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+
+        rolls = iter(
+            [
+                DiceResult(notation="1d8", rolls=[4], total=4),
+                DiceResult(notation="1d8", rolls=[6], total=6),
+                DiceResult(notation="1d8", rolls=[3], total=3),
+            ]
+        )
+
+        with patch("src.skills.rest.roll_dice", side_effect=lambda _: next(rolls)):
+            result = take_short_rest(char, hit_dice_to_spend=3)
+
+        assert result.hit_dice_spent == 3
+        assert result.hit_dice_remaining == 2
+        # (4+1) + (6+1) + (3+1) = 5 + 7 + 4 = 16
+        assert result.hp_healed == 16
+        assert result.rolls == [4, 6, 3]
+
+    def test_stops_at_max_hp(self):
+        char = CharacterResources(
+            hp_current=35,
+            hp_max=40,
+            con_modifier=2,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+
+        mock_roll = DiceResult(notation="1d8", rolls=[8], total=8)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = take_short_rest(char, hit_dice_to_spend=3)
+
+        # First die heals 10 (8+2), but only 5 room, so stops
+        assert result.hit_dice_spent == 1
+        assert result.hp_healed == 5
+        assert result.hp_current == 40
+
+    def test_stops_when_no_dice_left(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            con_modifier=0,
+            hit_dice=HitDice(die_type="d8", total=5, current=2),
+        )
+
+        mock_roll = DiceResult(notation="1d8", rolls=[4], total=4)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = take_short_rest(char, hit_dice_to_spend=5)
+
+        assert result.hit_dice_spent == 2  # Only had 2
+        assert result.hit_dice_remaining == 0
+
+    def test_minimum_1_hp_per_die(self):
+        """Even with negative CON, minimum 1 HP per die spent."""
+        char = CharacterResources(
+            hp_current=10,
+            hp_max=40,
+            con_modifier=-3,  # Negative CON
+            hit_dice=HitDice(die_type="d6", total=5, current=5),
+        )
+
+        mock_roll = DiceResult(notation="1d6", rolls=[1], total=1)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = take_short_rest(char, hit_dice_to_spend=1)
+
+        # 1 - 3 = -2, but minimum 1
+        assert result.hp_healed == 1
+
+
+# --- Long Rest Tests ---
+
+
+class TestTakeLongRest:
+    """Tests for take_long_rest function."""
+
+    def test_full_hp_recovery(self):
+        char = CharacterResources(
+            hp_current=10,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+        result = take_long_rest(char)
+
+        assert isinstance(result, LongRestResult)
+        assert result.hp_healed == 30
+        assert result.hp_current == 40
+        assert char.hp_current == 40
+
+    def test_hit_dice_recovery_half(self):
+        char = CharacterResources(
+            hp_current=40,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d10", total=6, current=0),
+        )
+        result = take_long_rest(char)
+
+        # Recover half of 6 = 3
+        assert result.hit_dice_recovered == 3
+        assert result.hit_dice_current == 3
+        assert char.hit_dice.current == 3
+
+    def test_hit_dice_recovery_minimum_1(self):
+        char = CharacterResources(
+            hp_current=40,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=1, current=0),
+        )
+        result = take_long_rest(char)
+
+        # Minimum 1 die recovered
+        assert result.hit_dice_recovered == 1
+        assert result.hit_dice_current == 1
+
+    def test_hit_dice_recovery_partial(self):
+        """If already have some dice, only recover up to half."""
+        char = CharacterResources(
+            hp_current=40,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=6, current=4),
+        )
+        result = take_long_rest(char)
+
+        # Max is 6, current is 4, can recover 3, but only room for 2
+        assert result.hit_dice_recovered == 2
+        assert result.hit_dice_current == 6
+
+    def test_spell_slots_restored(self):
+        char = CharacterResources(
+            hp_current=40,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+            spell_slots=SpellSlots(slots={1: (1, 4), 2: (0, 3), 3: (2, 2)}),
+        )
+        result = take_long_rest(char)
+
+        assert result.spell_slots_restored == {1: 3, 2: 3}
+        assert char.spell_slots.get_available(1) == 4
+        assert char.spell_slots.get_available(2) == 3
+        assert char.spell_slots.get_available(3) == 2
+
+    def test_no_spell_slots(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d10", total=5, current=2),
+            spell_slots=None,
+        )
+        result = take_long_rest(char)
+
+        assert result.spell_slots_restored == {}
+
+
+# --- Spend Hit Die Tests ---
+
+
+class TestSpendHitDie:
+    """Tests for spend_hit_die function."""
+
+    def test_spend_single_die(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            con_modifier=2,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+
+        mock_roll = DiceResult(notation="1d8", rolls=[6], total=6)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = spend_hit_die(char)
+
+        assert result == (6, 8)  # Rolled 6, healed 8 (6+2)
+        assert char.hit_dice.current == 4
+        assert char.hp_current == 28
+
+    def test_spend_when_empty(self):
+        char = CharacterResources(
+            hp_current=20,
+            hp_max=40,
+            hit_dice=HitDice(die_type="d8", total=5, current=0),
+        )
+        result = spend_hit_die(char)
+
+        assert result is None
+        assert char.hp_current == 20
+
+    def test_spend_capped_at_max(self):
+        char = CharacterResources(
+            hp_current=38,
+            hp_max=40,
+            con_modifier=3,
+            hit_dice=HitDice(die_type="d8", total=5, current=5),
+        )
+
+        mock_roll = DiceResult(notation="1d8", rolls=[8], total=8)
+        with patch("src.skills.rest.roll_dice", return_value=mock_roll):
+            result = spend_hit_die(char)
+
+        # Rolled 8, +3 CON = 11, but only 2 room
+        assert result == (8, 2)
+        assert char.hp_current == 40


### PR DESCRIPTION
## Summary
- Implements Phase 5 of specs/mechanics.md
- Complete short rest and long rest mechanics
- 38 new tests (148 total)

## Short Rest (1 hour)
| Action | Result |
|--------|--------|
| Spend hit die | Roll die + CON mod HP healed |
| Minimum per die | 1 HP (even with negative CON) |
| Stops when | At max HP or no dice left |

## Long Rest (8 hours)
| Recovery | Amount |
|----------|--------|
| HP | Full (to max) |
| Hit Dice | Half of max (minimum 1) |
| Spell Slots | All restored |
| Temp HP | Unchanged |

## New Models
- `HitDice` - die type, total, current with spend/recover
- `SpellSlots` - level-based slot tracking
- `CharacterResources` - HP, temp HP, CON mod, hit dice, spell slots
- `ShortRestResult` / `LongRestResult` - outcomes

## Functions Added
| Function | Description |
|----------|-------------|
| `take_short_rest()` | Spend dice to heal |
| `take_long_rest()` | Full recovery |
| `spend_hit_die()` | Single die helper |

## Test plan
- [x] 148 tests pass locally
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] Pyright type check passes
- [ ] CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)