### PR TITLE
feat: implement core ontology models per specs/ontology.md

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,110 @@
+"""
+Core Data Models for TTA-Solo.
+
+These models define the ontology - the structure of game entities,
+events, universes, and relationships.
+
+Models are stored in:
+- Dolt: Entities, Events, Universes (the "Truth")
+- Neo4j: Relationships, Embeddings (the "Context")
+"""
+
+from src.models.entity import (
+    AbilityScores,
+    Entity,
+    EntityStats,
+    EntityType,
+    FactionProperties,
+    ItemProperties,
+    LocationProperties,
+    create_character,
+    create_faction,
+    create_item,
+    create_location,
+)
+from src.models.event import (
+    CheckPayload,
+    CombatPayload,
+    DialoguePayload,
+    Event,
+    EventOutcome,
+    EventType,
+    ForkPayload,
+    ItemPayload,
+    RestPayload,
+    TransactionPayload,
+    TravelPayload,
+    create_check_event,
+    create_combat_event,
+    create_dialogue_event,
+    create_fork_event,
+    create_travel_event,
+)
+from src.models.relationships import (
+    FearsRelationship,
+    KnowsRelationship,
+    LocatedInRelationship,
+    Relationship,
+    RelationshipType,
+    VariantOfRelationship,
+    create_knows_relationship,
+    create_located_in,
+    create_variant,
+)
+from src.models.universe import (
+    Universe,
+    UniverseConnection,
+    UniverseStatus,
+    create_fork,
+    create_prime_material,
+    create_shared_adventure,
+)
+
+__all__ = [
+    # Entity
+    "Entity",
+    "EntityType",
+    "EntityStats",
+    "AbilityScores",
+    "ItemProperties",
+    "LocationProperties",
+    "FactionProperties",
+    "create_character",
+    "create_location",
+    "create_item",
+    "create_faction",
+    # Event
+    "Event",
+    "EventType",
+    "EventOutcome",
+    "CombatPayload",
+    "DialoguePayload",
+    "TravelPayload",
+    "ItemPayload",
+    "TransactionPayload",
+    "CheckPayload",
+    "RestPayload",
+    "ForkPayload",
+    "create_combat_event",
+    "create_dialogue_event",
+    "create_travel_event",
+    "create_check_event",
+    "create_fork_event",
+    # Universe
+    "Universe",
+    "UniverseStatus",
+    "UniverseConnection",
+    "create_prime_material",
+    "create_fork",
+    "create_shared_adventure",
+    # Relationships
+    "Relationship",
+    "RelationshipType",
+    "KnowsRelationship",
+    "LocatedInRelationship",
+    "FearsRelationship",
+    "VariantOfRelationship",
+    "create_knows_relationship",
+    "create_located_in",
+    "create_variant",
+]

--- a/src/models/entity.py
+++ b/src/models/entity.py
@@ -1,0 +1,262 @@
+"""
+Entity Models for TTA-Solo.
+
+Defines the core data structures for game entities:
+Characters, Locations, Items, and Factions.
+
+These models represent the "Truth" stored in Dolt.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class EntityType(str, Enum):
+    """Types of entities in the game world."""
+
+    CHARACTER = "character"
+    LOCATION = "location"
+    ITEM = "item"
+    FACTION = "faction"
+
+
+class AbilityScores(BaseModel):
+    """The six ability scores per SRD 5e."""
+
+    str_: int = Field(default=10, ge=1, le=30, alias="str")
+    dex: int = Field(default=10, ge=1, le=30)
+    con: int = Field(default=10, ge=1, le=30)
+    int_: int = Field(default=10, ge=1, le=30, alias="int")
+    wis: int = Field(default=10, ge=1, le=30)
+    cha: int = Field(default=10, ge=1, le=30)
+
+    model_config = {"populate_by_name": True}
+
+    def get(self, ability: str) -> int:
+        """Get ability score by name."""
+        mapping = {
+            "str": self.str_,
+            "dex": self.dex,
+            "con": self.con,
+            "int": self.int_,
+            "wis": self.wis,
+            "cha": self.cha,
+        }
+        if ability not in mapping:
+            raise ValueError(f"Unknown ability: {ability}")
+        return mapping[ability]
+
+    def modifier(self, ability: str) -> int:
+        """Get ability modifier by name."""
+        return (self.get(ability) - 10) // 2
+
+
+class EntityStats(BaseModel):
+    """
+    Combat and mechanical stats for an entity.
+
+    Used primarily for characters and monsters.
+    """
+
+    srd_block: str | None = Field(
+        default=None, description="Reference to SRD 5e statblock, e.g., 'Goblin'"
+    )
+    hp_current: int = Field(ge=0, description="Current hit points")
+    hp_max: int = Field(ge=1, description="Maximum hit points")
+    hp_temp: int = Field(default=0, ge=0, description="Temporary hit points")
+    ac: int = Field(default=10, ge=0, description="Armor class")
+    speed: int = Field(default=30, ge=0, description="Movement speed in feet")
+    abilities: AbilityScores = Field(default_factory=AbilityScores)
+    proficiency_bonus: int = Field(default=2, ge=0)
+    level: int = Field(default=1, ge=1)
+    experience: int = Field(default=0, ge=0)
+
+
+class ItemProperties(BaseModel):
+    """Properties specific to items."""
+
+    value_copper: int = Field(default=0, ge=0, description="Value in copper pieces")
+    weight: float = Field(default=0.0, ge=0, description="Weight in pounds")
+    rarity: Literal["common", "uncommon", "rare", "very_rare", "legendary", "artifact"] = "common"
+    magical: bool = False
+    attunement_required: bool = False
+    consumable: bool = False
+    quantity: int = Field(default=1, ge=1)
+
+
+class LocationProperties(BaseModel):
+    """Properties specific to locations."""
+
+    region: str | None = None
+    terrain: str | None = None
+    climate: str | None = None
+    population: int | None = None
+    is_dungeon: bool = False
+    danger_level: int = Field(default=0, ge=0, le=20, description="0=safe, 20=deadly")
+
+
+class FactionProperties(BaseModel):
+    """Properties specific to factions."""
+
+    alignment: str | None = None
+    influence: int = Field(default=0, ge=0, le=100, description="Political influence 0-100")
+    wealth: int = Field(default=0, ge=0, description="Faction wealth in gold pieces")
+    member_count: int | None = None
+
+
+class Entity(BaseModel):
+    """
+    Core entity model - the fundamental game object.
+
+    Represents characters, locations, items, and factions.
+    Stored in Dolt's `entities` table.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    universe_id: UUID = Field(description="Which timeline this entity exists in")
+    type: EntityType
+    name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="", description="Natural language description for embedding")
+    tags: list[str] = Field(default_factory=list, description="Categorical tags for filtering")
+
+    # Type-specific properties (only one should be set based on type)
+    stats: EntityStats | None = Field(default=None, description="For characters/monsters")
+    item_properties: ItemProperties | None = Field(default=None, description="For items")
+    location_properties: LocationProperties | None = Field(
+        default=None, description="For locations"
+    )
+    faction_properties: FactionProperties | None = Field(default=None, description="For factions")
+
+    # Relationships (stored as IDs, resolved via Neo4j)
+    current_location_id: UUID | None = Field(default=None, description="Where this entity is")
+    owner_id: UUID | None = Field(default=None, description="Who owns this (for items)")
+
+    # Metadata
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    is_active: bool = Field(default=True, description="Soft delete flag")
+
+    def is_character(self) -> bool:
+        """Check if this is a character entity."""
+        return self.type == EntityType.CHARACTER
+
+    def is_location(self) -> bool:
+        """Check if this is a location entity."""
+        return self.type == EntityType.LOCATION
+
+    def is_item(self) -> bool:
+        """Check if this is an item entity."""
+        return self.type == EntityType.ITEM
+
+    def is_faction(self) -> bool:
+        """Check if this is a faction entity."""
+        return self.type == EntityType.FACTION
+
+
+def create_character(
+    universe_id: UUID,
+    name: str,
+    description: str = "",
+    hp_max: int = 10,
+    ac: int = 10,
+    abilities: AbilityScores | None = None,
+    tags: list[str] | None = None,
+    location_id: UUID | None = None,
+) -> Entity:
+    """Factory function to create a character entity."""
+    return Entity(
+        universe_id=universe_id,
+        type=EntityType.CHARACTER,
+        name=name,
+        description=description,
+        tags=tags or ["character"],
+        stats=EntityStats(
+            hp_current=hp_max,
+            hp_max=hp_max,
+            ac=ac,
+            abilities=abilities or AbilityScores(),
+        ),
+        current_location_id=location_id,
+    )
+
+
+def create_location(
+    universe_id: UUID,
+    name: str,
+    description: str = "",
+    region: str | None = None,
+    terrain: str | None = None,
+    danger_level: int = 0,
+    tags: list[str] | None = None,
+) -> Entity:
+    """Factory function to create a location entity."""
+    return Entity(
+        universe_id=universe_id,
+        type=EntityType.LOCATION,
+        name=name,
+        description=description,
+        tags=tags or ["location"],
+        location_properties=LocationProperties(
+            region=region,
+            terrain=terrain,
+            danger_level=danger_level,
+        ),
+    )
+
+
+def create_item(
+    universe_id: UUID,
+    name: str,
+    description: str = "",
+    value_copper: int = 0,
+    weight: float = 0.0,
+    rarity: Literal["common", "uncommon", "rare", "very_rare", "legendary", "artifact"] = "common",
+    magical: bool = False,
+    tags: list[str] | None = None,
+    owner_id: UUID | None = None,
+    location_id: UUID | None = None,
+) -> Entity:
+    """Factory function to create an item entity."""
+    return Entity(
+        universe_id=universe_id,
+        type=EntityType.ITEM,
+        name=name,
+        description=description,
+        tags=tags or ["item"],
+        item_properties=ItemProperties(
+            value_copper=value_copper,
+            weight=weight,
+            rarity=rarity,
+            magical=magical,
+        ),
+        owner_id=owner_id,
+        current_location_id=location_id,
+    )
+
+
+def create_faction(
+    universe_id: UUID,
+    name: str,
+    description: str = "",
+    alignment: str | None = None,
+    influence: int = 0,
+    tags: list[str] | None = None,
+) -> Entity:
+    """Factory function to create a faction entity."""
+    return Entity(
+        universe_id=universe_id,
+        type=EntityType.FACTION,
+        name=name,
+        description=description,
+        tags=tags or ["faction"],
+        faction_properties=FactionProperties(
+            alignment=alignment,
+            influence=influence,
+        ),
+    )

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -1,0 +1,375 @@
+"""
+Event Models for TTA-Solo.
+
+Events are the atomic units of story - immutable records of what happened.
+Stored in Dolt's `events` table as an append-only log.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class EventType(str, Enum):
+    """Types of events that can occur in the game world."""
+
+    # Combat events
+    COMBAT_START = "combat_start"
+    COMBAT_ROUND = "combat_round"
+    COMBAT_END = "combat_end"
+    ATTACK = "attack"
+    DAMAGE = "damage"
+    HEAL = "heal"
+    DEATH = "death"
+
+    # Social events
+    DIALOGUE = "dialogue"
+    PERSUASION = "persuasion"
+    INTIMIDATION = "intimidation"
+    DECEPTION = "deception"
+
+    # Movement events
+    TRAVEL = "travel"
+    ENTER_LOCATION = "enter_location"
+    EXIT_LOCATION = "exit_location"
+
+    # Item events
+    ITEM_PICKUP = "item_pickup"
+    ITEM_DROP = "item_drop"
+    ITEM_TRANSFER = "item_transfer"
+    ITEM_USE = "item_use"
+    ITEM_EQUIP = "item_equip"
+    ITEM_UNEQUIP = "item_unequip"
+
+    # Economy events
+    TRANSACTION_BUY = "transaction_buy"
+    TRANSACTION_SELL = "transaction_sell"
+    LOOT = "loot"
+
+    # Rest events
+    SHORT_REST = "short_rest"
+    LONG_REST = "long_rest"
+
+    # Skill/ability events
+    SKILL_CHECK = "skill_check"
+    SAVING_THROW = "saving_throw"
+    ABILITY_CHECK = "ability_check"
+
+    # World events
+    FORK = "fork"
+    WORLD_CHANGE = "world_change"
+    TIME_PASSAGE = "time_passage"
+
+    # Meta events
+    SESSION_START = "session_start"
+    SESSION_END = "session_end"
+    PLAYER_JOIN = "player_join"
+    PLAYER_LEAVE = "player_leave"
+
+
+class EventOutcome(str, Enum):
+    """Possible outcomes of an event."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL = "partial"
+    CRITICAL_SUCCESS = "critical_success"
+    CRITICAL_FAILURE = "critical_failure"
+    NEUTRAL = "neutral"
+
+
+class CombatPayload(BaseModel):
+    """Payload for combat-related events."""
+
+    target_id: UUID | None = None
+    weapon: str | None = None
+    attack_roll: int | None = None
+    damage_roll: int | None = None
+    damage_type: str | None = None
+    is_critical: bool = False
+    is_fumble: bool = False
+    conditions_applied: list[str] = Field(default_factory=list)
+
+
+class DialoguePayload(BaseModel):
+    """Payload for dialogue events."""
+
+    listener_id: UUID | None = None
+    text: str
+    emotion: str | None = None
+    language: str = "common"
+
+
+class TravelPayload(BaseModel):
+    """Payload for travel events."""
+
+    from_location_id: UUID | None = None
+    to_location_id: UUID
+    travel_method: str = "walking"
+    distance: int | None = None  # in feet
+    duration_minutes: int | None = None
+
+
+class ItemPayload(BaseModel):
+    """Payload for item-related events."""
+
+    item_id: UUID
+    item_name: str
+    quantity: int = 1
+    from_entity_id: UUID | None = None
+    to_entity_id: UUID | None = None
+
+
+class TransactionPayload(BaseModel):
+    """Payload for economic transactions."""
+
+    counterparty_id: UUID | None = None
+    items: list[dict[str, Any]] = Field(default_factory=list)
+    currency_amount: int = 0  # in copper pieces
+    transaction_type: str = "purchase"
+
+
+class CheckPayload(BaseModel):
+    """Payload for skill checks and saving throws."""
+
+    check_type: str  # skill name or ability
+    dc: int
+    roll: int
+    modifier: int
+    total: int
+    advantage: bool = False
+    disadvantage: bool = False
+
+
+class RestPayload(BaseModel):
+    """Payload for rest events."""
+
+    rest_type: str  # "short" or "long"
+    hp_healed: int = 0
+    hit_dice_spent: int = 0
+    hit_dice_recovered: int = 0
+    spell_slots_recovered: dict[int, int] = Field(default_factory=dict)
+
+
+class ForkPayload(BaseModel):
+    """Payload for timeline fork events."""
+
+    parent_universe_id: UUID
+    child_universe_id: UUID
+    fork_reason: str
+    fork_point_event_id: UUID | None = None
+
+
+class Event(BaseModel):
+    """
+    Core event model - the atomic unit of story.
+
+    Events are immutable records stored in Dolt's event log.
+    They capture what happened, who did it, and the outcome.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    universe_id: UUID = Field(description="Which timeline this event occurred in")
+    event_type: EventType
+    timestamp: datetime = Field(
+        default_factory=datetime.utcnow, description="When this event occurred (in-game time)"
+    )
+    real_timestamp: datetime = Field(
+        default_factory=datetime.utcnow, description="When this event was recorded (real time)"
+    )
+
+    # Who and what
+    actor_id: UUID = Field(description="Who initiated this event")
+    target_id: UUID | None = Field(default=None, description="Who/what was affected")
+    location_id: UUID | None = Field(default=None, description="Where this happened")
+
+    # Outcome
+    outcome: EventOutcome = EventOutcome.NEUTRAL
+    roll: int | None = Field(default=None, description="The d20 roll if applicable")
+
+    # Payload (type-specific data)
+    payload: dict[str, Any] = Field(default_factory=dict, description="Event-specific data")
+
+    # Narrative
+    narrative_summary: str = Field(default="", description="LLM-generated narrative description")
+
+    # Causality chain
+    caused_by_event_id: UUID | None = Field(
+        default=None, description="Parent event that triggered this"
+    )
+
+    def is_combat_event(self) -> bool:
+        """Check if this is a combat-related event."""
+        return self.event_type in {
+            EventType.COMBAT_START,
+            EventType.COMBAT_ROUND,
+            EventType.COMBAT_END,
+            EventType.ATTACK,
+            EventType.DAMAGE,
+            EventType.HEAL,
+            EventType.DEATH,
+        }
+
+    def is_social_event(self) -> bool:
+        """Check if this is a social event."""
+        return self.event_type in {
+            EventType.DIALOGUE,
+            EventType.PERSUASION,
+            EventType.INTIMIDATION,
+            EventType.DECEPTION,
+        }
+
+    def is_movement_event(self) -> bool:
+        """Check if this is a movement event."""
+        return self.event_type in {
+            EventType.TRAVEL,
+            EventType.ENTER_LOCATION,
+            EventType.EXIT_LOCATION,
+        }
+
+
+def create_combat_event(
+    universe_id: UUID,
+    actor_id: UUID,
+    event_type: EventType,
+    target_id: UUID | None = None,
+    location_id: UUID | None = None,
+    attack_roll: int | None = None,
+    damage: int | None = None,
+    damage_type: str | None = None,
+    is_critical: bool = False,
+    outcome: EventOutcome = EventOutcome.NEUTRAL,
+    narrative: str = "",
+) -> Event:
+    """Factory function to create a combat event."""
+    payload = CombatPayload(
+        target_id=target_id,
+        attack_roll=attack_roll,
+        damage_roll=damage,
+        damage_type=damage_type,
+        is_critical=is_critical,
+    )
+    return Event(
+        universe_id=universe_id,
+        event_type=event_type,
+        actor_id=actor_id,
+        target_id=target_id,
+        location_id=location_id,
+        outcome=outcome,
+        roll=attack_roll,
+        payload=payload.model_dump(),
+        narrative_summary=narrative,
+    )
+
+
+def create_dialogue_event(
+    universe_id: UUID,
+    speaker_id: UUID,
+    text: str,
+    listener_id: UUID | None = None,
+    location_id: UUID | None = None,
+    emotion: str | None = None,
+    narrative: str = "",
+) -> Event:
+    """Factory function to create a dialogue event."""
+    payload = DialoguePayload(
+        listener_id=listener_id,
+        text=text,
+        emotion=emotion,
+    )
+    return Event(
+        universe_id=universe_id,
+        event_type=EventType.DIALOGUE,
+        actor_id=speaker_id,
+        target_id=listener_id,
+        location_id=location_id,
+        outcome=EventOutcome.NEUTRAL,
+        payload=payload.model_dump(),
+        narrative_summary=narrative or text,
+    )
+
+
+def create_travel_event(
+    universe_id: UUID,
+    traveler_id: UUID,
+    to_location_id: UUID,
+    from_location_id: UUID | None = None,
+    travel_method: str = "walking",
+    narrative: str = "",
+) -> Event:
+    """Factory function to create a travel event."""
+    payload = TravelPayload(
+        from_location_id=from_location_id,
+        to_location_id=to_location_id,
+        travel_method=travel_method,
+    )
+    return Event(
+        universe_id=universe_id,
+        event_type=EventType.TRAVEL,
+        actor_id=traveler_id,
+        location_id=to_location_id,
+        outcome=EventOutcome.SUCCESS,
+        payload=payload.model_dump(),
+        narrative_summary=narrative,
+    )
+
+
+def create_check_event(
+    universe_id: UUID,
+    actor_id: UUID,
+    event_type: EventType,
+    check_type: str,
+    dc: int,
+    roll: int,
+    modifier: int,
+    outcome: EventOutcome,
+    location_id: UUID | None = None,
+    narrative: str = "",
+) -> Event:
+    """Factory function to create a skill check or saving throw event."""
+    payload = CheckPayload(
+        check_type=check_type,
+        dc=dc,
+        roll=roll,
+        modifier=modifier,
+        total=roll + modifier,
+    )
+    return Event(
+        universe_id=universe_id,
+        event_type=event_type,
+        actor_id=actor_id,
+        location_id=location_id,
+        outcome=outcome,
+        roll=roll,
+        payload=payload.model_dump(),
+        narrative_summary=narrative,
+    )
+
+
+def create_fork_event(
+    parent_universe_id: UUID,
+    child_universe_id: UUID,
+    actor_id: UUID,
+    fork_reason: str,
+    fork_point_event_id: UUID | None = None,
+) -> Event:
+    """Factory function to create a timeline fork event."""
+    payload = ForkPayload(
+        parent_universe_id=parent_universe_id,
+        child_universe_id=child_universe_id,
+        fork_reason=fork_reason,
+        fork_point_event_id=fork_point_event_id,
+    )
+    return Event(
+        universe_id=child_universe_id,
+        event_type=EventType.FORK,
+        actor_id=actor_id,
+        outcome=EventOutcome.SUCCESS,
+        payload=payload.model_dump(),
+        narrative_summary=f"Timeline forked: {fork_reason}",
+    )

--- a/src/models/relationships.py
+++ b/src/models/relationships.py
@@ -1,0 +1,207 @@
+"""
+Relationship Models for TTA-Solo.
+
+Defines the relationship types used in Neo4j for the "soft state" -
+connections, feelings, and context that enhance narrative retrieval.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class RelationshipType(str, Enum):
+    """Types of relationships between entities in Neo4j."""
+
+    # Character-to-Character
+    KNOWS = "KNOWS"  # Basic acquaintance
+    ALLIED_WITH = "ALLIED_WITH"
+    HOSTILE_TO = "HOSTILE_TO"
+    SERVES = "SERVES"  # Subordinate relationship
+    COMMANDS = "COMMANDS"  # Superior relationship
+    RELATED_TO = "RELATED_TO"  # Family
+    LOVES = "LOVES"
+    HATES = "HATES"
+    FEARS = "FEARS"
+    RESPECTS = "RESPECTS"
+    DISTRUSTS = "DISTRUSTS"
+
+    # Character-to-Location
+    LOCATED_IN = "LOCATED_IN"
+    BORN_IN = "BORN_IN"
+    LIVES_IN = "LIVES_IN"
+    WORKS_IN = "WORKS_IN"
+    OWNS = "OWNS"  # Also Item-to-Character (reversed)
+    VISITED = "VISITED"
+
+    # Character-to-Item
+    CARRIES = "CARRIES"
+    WIELDS = "WIELDS"
+    WEARS = "WEARS"
+    CREATED = "CREATED"
+    SEEKS = "SEEKS"
+
+    # Character-to-Faction
+    MEMBER_OF = "MEMBER_OF"
+    LEADS = "LEADS"
+    OPPOSES = "OPPOSES"
+
+    # Character-to-Concept
+    BELIEVES_IN = "BELIEVES_IN"
+    DESIRES = "DESIRES"
+    SKILLED_IN = "SKILLED_IN"
+
+    # Location-to-Location
+    CONNECTED_TO = "CONNECTED_TO"
+    CONTAINS = "CONTAINS"  # Nested locations
+    NEAR = "NEAR"
+    BORDERS = "BORDERS"
+
+    # Location-to-Concept
+    HAS_ATMOSPHERE = "HAS_ATMOSPHERE"  # Mood/vibe
+
+    # Event-to-Event
+    CAUSED = "CAUSED"
+    PRECEDED = "PRECEDED"
+    FOLLOWED = "FOLLOWED"
+
+    # Entity-to-Entity (cross-timeline)
+    VARIANT_OF = "VARIANT_OF"  # Same entity, different universe
+
+
+class Relationship(BaseModel):
+    """
+    A relationship between two entities in Neo4j.
+
+    Relationships capture the "soft state" - feelings, connections,
+    and context that help the AI find relevant information.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    universe_id: UUID = Field(description="Which timeline this relationship exists in")
+    relationship_type: RelationshipType
+    from_entity_id: UUID
+    to_entity_id: UUID
+
+    # Relationship properties
+    strength: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="How strong the relationship is (0-1)"
+    )
+    trust: float | None = Field(default=None, ge=-1.0, le=1.0, description="Trust level (-1 to 1)")
+    description: str = Field(default="", description="Narrative description")
+
+    # Metadata
+    established_at: datetime = Field(default_factory=datetime.utcnow)
+    last_interaction: datetime | None = None
+    is_active: bool = Field(default=True)
+
+    # For temporal relationships
+    started_event_id: UUID | None = Field(
+        default=None, description="Event that created this relationship"
+    )
+    ended_event_id: UUID | None = Field(
+        default=None, description="Event that ended this relationship"
+    )
+
+
+class KnowsRelationship(Relationship):
+    """Extended model for KNOWS relationships with additional properties."""
+
+    relationship_type: RelationshipType = RelationshipType.KNOWS
+    trust: float = Field(default=0.5, ge=-1.0, le=1.0)
+    familiarity: float = Field(
+        default=0.5, ge=0.0, le=1.0, description="How well they know each other"
+    )
+    last_met_location_id: UUID | None = None
+
+
+class LocatedInRelationship(Relationship):
+    """Extended model for LOCATED_IN relationships."""
+
+    relationship_type: RelationshipType = RelationshipType.LOCATED_IN
+    is_current: bool = Field(default=True, description="Is this their current location?")
+    arrived_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class FearsRelationship(Relationship):
+    """Extended model for FEARS relationships to concepts or entities."""
+
+    relationship_type: RelationshipType = RelationshipType.FEARS
+    intensity: float = Field(default=0.5, ge=0.0, le=1.0, description="Fear intensity")
+    is_phobia: bool = Field(default=False, description="Is this an irrational fear?")
+    origin_event_id: UUID | None = Field(default=None, description="What caused this fear")
+
+
+class VariantOfRelationship(Relationship):
+    """
+    Extended model for VARIANT_OF relationships (cross-timeline entities).
+
+    When an entity diverges between timelines, we create a variant node
+    rather than duplicating the entire graph.
+    """
+
+    relationship_type: RelationshipType = RelationshipType.VARIANT_OF
+    diverged_at_event_id: UUID | None = Field(
+        default=None, description="The fork event where divergence occurred"
+    )
+    changes_from_original: dict[str, str] = Field(
+        default_factory=dict, description="What changed from the original"
+    )
+
+
+def create_knows_relationship(
+    universe_id: UUID,
+    from_id: UUID,
+    to_id: UUID,
+    trust: float = 0.5,
+    familiarity: float = 0.5,
+    description: str = "",
+) -> KnowsRelationship:
+    """Create a KNOWS relationship between two characters."""
+    return KnowsRelationship(
+        universe_id=universe_id,
+        from_entity_id=from_id,
+        to_entity_id=to_id,
+        trust=trust,
+        familiarity=familiarity,
+        description=description,
+    )
+
+
+def create_located_in(
+    universe_id: UUID,
+    entity_id: UUID,
+    location_id: UUID,
+) -> LocatedInRelationship:
+    """Create a LOCATED_IN relationship."""
+    return LocatedInRelationship(
+        universe_id=universe_id,
+        from_entity_id=entity_id,
+        to_entity_id=location_id,
+        is_current=True,
+    )
+
+
+def create_variant(
+    original_entity_id: UUID,
+    variant_entity_id: UUID,
+    variant_universe_id: UUID,
+    diverged_at_event_id: UUID | None = None,
+    changes: dict[str, str] | None = None,
+) -> VariantOfRelationship:
+    """
+    Create a VARIANT_OF relationship for cross-timeline entities.
+
+    Used when an entity in a forked timeline diverges from its original.
+    """
+    return VariantOfRelationship(
+        universe_id=variant_universe_id,
+        from_entity_id=variant_entity_id,
+        to_entity_id=original_entity_id,
+        diverged_at_event_id=diverged_at_event_id,
+        changes_from_original=changes or {},
+    )

--- a/src/models/universe.py
+++ b/src/models/universe.py
@@ -1,0 +1,160 @@
+"""
+Universe Models for TTA-Solo.
+
+Universes represent timeline branches in the multiverse.
+Each universe is a Dolt branch, allowing Git-like versioning of game state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class UniverseStatus(str, Enum):
+    """Status of a universe/timeline."""
+
+    ACTIVE = "active"  # Currently playable
+    ARCHIVED = "archived"  # Preserved but not active
+    MERGED = "merged"  # Content merged into parent
+    ABANDONED = "abandoned"  # No longer maintained
+
+
+class Universe(BaseModel):
+    """
+    A timeline/universe in the multiverse.
+
+    Each universe corresponds to a Dolt branch.
+    Forking creates a new branch with zero-cost copy.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="")
+
+    # Lineage
+    parent_universe_id: UUID | None = Field(
+        default=None, description="The universe this was forked from"
+    )
+    fork_point_event_id: UUID | None = Field(
+        default=None, description="The event where the fork occurred"
+    )
+    depth: int = Field(default=0, ge=0, description="How many forks from Prime Material")
+
+    # Ownership
+    owner_id: UUID | None = Field(default=None, description="Player who owns this branch")
+    is_shared: bool = Field(default=False, description="Whether others can join")
+
+    # Status
+    status: UniverseStatus = UniverseStatus.ACTIVE
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    last_event_at: datetime | None = Field(default=None)
+
+    # Dolt integration
+    dolt_branch: str = Field(default="", description="Corresponding Dolt branch name")
+
+    def is_prime_material(self) -> bool:
+        """Check if this is the root/canonical universe."""
+        return self.parent_universe_id is None and self.depth == 0
+
+    def is_active(self) -> bool:
+        """Check if this universe is currently active."""
+        return self.status == UniverseStatus.ACTIVE
+
+
+class UniverseConnection(BaseModel):
+    """
+    A connection between two universes allowing travel.
+
+    Some universes can be linked, allowing characters to travel between them.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    from_universe_id: UUID
+    to_universe_id: UUID
+    connection_type: str = Field(
+        default="portal", description="How travel occurs: portal, spell, artifact, etc."
+    )
+    bidirectional: bool = Field(default=True)
+    is_active: bool = Field(default=True)
+    location_id: UUID | None = Field(
+        default=None, description="Where the connection exists in from_universe"
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+def create_prime_material(name: str = "Prime Material", description: str = "") -> Universe:
+    """Create the root canonical universe."""
+    universe = Universe(
+        name=name,
+        description=description or "The canonical timeline.",
+        parent_universe_id=None,
+        depth=0,
+        is_shared=True,
+    )
+    universe.dolt_branch = "main"
+    return universe
+
+
+def create_fork(
+    parent: Universe,
+    name: str,
+    owner_id: UUID | None = None,
+    fork_reason: str = "",
+    fork_point_event_id: UUID | None = None,
+) -> Universe:
+    """
+    Create a new universe forked from a parent.
+
+    Args:
+        parent: The universe to fork from
+        name: Name for the new universe
+        owner_id: Player who owns this branch
+        fork_reason: Why the fork was created
+        fork_point_event_id: The event that triggered the fork
+
+    Returns:
+        New Universe instance
+    """
+    universe = Universe(
+        name=name,
+        description=fork_reason,
+        parent_universe_id=parent.id,
+        fork_point_event_id=fork_point_event_id,
+        depth=parent.depth + 1,
+        owner_id=owner_id,
+        is_shared=False,
+    )
+    # Generate Dolt branch name
+    safe_name = name.lower().replace(" ", "_").replace("-", "_")
+    if owner_id:
+        universe.dolt_branch = f"user/{owner_id}/{safe_name}"
+    else:
+        universe.dolt_branch = f"fork/{universe.id}"
+    return universe
+
+
+def create_shared_adventure(
+    parent: Universe,
+    name: str,
+    description: str = "",
+) -> Universe:
+    """
+    Create a shared adventure that multiple players can fork.
+
+    Like a template that others can branch from.
+    """
+    universe = Universe(
+        name=name,
+        description=description,
+        parent_universe_id=parent.id,
+        depth=parent.depth + 1,
+        is_shared=True,
+    )
+    safe_name = name.lower().replace(" ", "_").replace("-", "_")
+    universe.dolt_branch = f"adventure/{safe_name}"
+    return universe

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,445 @@
+"""Tests for core ontology models."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from src.models import (
+    AbilityScores,
+    EntityType,
+    Event,
+    EventOutcome,
+    EventType,
+    RelationshipType,
+    UniverseStatus,
+    create_character,
+    create_combat_event,
+    create_dialogue_event,
+    create_faction,
+    create_fork,
+    create_fork_event,
+    create_item,
+    create_knows_relationship,
+    create_located_in,
+    create_location,
+    create_prime_material,
+    create_travel_event,
+    create_variant,
+)
+
+# --- AbilityScores Tests ---
+
+
+class TestAbilityScores:
+    """Tests for AbilityScores model."""
+
+    def test_default_values(self):
+        abilities = AbilityScores()
+        assert abilities.str_ == 10
+        assert abilities.dex == 10
+        assert abilities.con == 10
+        assert abilities.int_ == 10
+        assert abilities.wis == 10
+        assert abilities.cha == 10
+
+    def test_get_ability(self):
+        abilities = AbilityScores(str=16, dex=14)
+        assert abilities.get("str") == 16
+        assert abilities.get("dex") == 14
+
+    def test_modifier_calculation(self):
+        abilities = AbilityScores(str=16, dex=8, con=15)
+        assert abilities.modifier("str") == 3  # (16-10)//2
+        assert abilities.modifier("dex") == -1  # (8-10)//2
+        assert abilities.modifier("con") == 2  # (15-10)//2
+
+    def test_alias_works(self):
+        # Can use "str" and "int" as field names
+        abilities = AbilityScores(**{"str": 18, "int": 14})
+        assert abilities.str_ == 18
+        assert abilities.int_ == 14
+
+
+# --- Entity Tests ---
+
+
+class TestEntity:
+    """Tests for Entity model."""
+
+    def test_create_character_factory(self):
+        universe_id = uuid4()
+        char = create_character(
+            universe_id=universe_id,
+            name="Gandalf",
+            hp_max=45,
+            ac=12,
+        )
+
+        assert char.type == EntityType.CHARACTER
+        assert char.name == "Gandalf"
+        assert char.stats is not None
+        assert char.stats.hp_max == 45
+        assert char.stats.hp_current == 45
+        assert char.stats.ac == 12
+        assert char.is_character() is True
+
+    def test_create_location_factory(self):
+        universe_id = uuid4()
+        loc = create_location(
+            universe_id=universe_id,
+            name="Moria",
+            description="An ancient dwarven kingdom",
+            terrain="underground",
+            danger_level=15,
+        )
+
+        assert loc.type == EntityType.LOCATION
+        assert loc.name == "Moria"
+        assert loc.location_properties is not None
+        assert loc.location_properties.terrain == "underground"
+        assert loc.location_properties.danger_level == 15
+        assert loc.is_location() is True
+
+    def test_create_item_factory(self):
+        universe_id = uuid4()
+        item = create_item(
+            universe_id=universe_id,
+            name="Longsword +1",
+            value_copper=1500,
+            magical=True,
+            rarity="uncommon",
+        )
+
+        assert item.type == EntityType.ITEM
+        assert item.name == "Longsword +1"
+        assert item.item_properties is not None
+        assert item.item_properties.magical is True
+        assert item.item_properties.rarity == "uncommon"
+        assert item.is_item() is True
+
+    def test_create_faction_factory(self):
+        universe_id = uuid4()
+        faction = create_faction(
+            universe_id=universe_id,
+            name="Harpers",
+            alignment="Chaotic Good",
+            influence=75,
+        )
+
+        assert faction.type == EntityType.FACTION
+        assert faction.faction_properties is not None
+        assert faction.faction_properties.alignment == "Chaotic Good"
+        assert faction.faction_properties.influence == 75
+        assert faction.is_faction() is True
+
+    def test_entity_tags(self):
+        universe_id = uuid4()
+        char = create_character(
+            universe_id=universe_id,
+            name="Goblin",
+            tags=["monster", "humanoid", "hostile"],
+        )
+        assert "monster" in char.tags
+        assert "hostile" in char.tags
+
+
+# --- Event Tests ---
+
+
+class TestEvent:
+    """Tests for Event model."""
+
+    def test_create_combat_event(self):
+        universe_id = uuid4()
+        actor_id = uuid4()
+        target_id = uuid4()
+
+        event = create_combat_event(
+            universe_id=universe_id,
+            actor_id=actor_id,
+            event_type=EventType.ATTACK,
+            target_id=target_id,
+            attack_roll=18,
+            damage=12,
+            damage_type="slashing",
+            outcome=EventOutcome.SUCCESS,
+        )
+
+        assert event.event_type == EventType.ATTACK
+        assert event.actor_id == actor_id
+        assert event.target_id == target_id
+        assert event.outcome == EventOutcome.SUCCESS
+        assert event.roll == 18
+        assert event.payload["damage_roll"] == 12
+        assert event.is_combat_event() is True
+
+    def test_create_dialogue_event(self):
+        universe_id = uuid4()
+        speaker_id = uuid4()
+        listener_id = uuid4()
+
+        event = create_dialogue_event(
+            universe_id=universe_id,
+            speaker_id=speaker_id,
+            text="You shall not pass!",
+            listener_id=listener_id,
+            emotion="angry",
+        )
+
+        assert event.event_type == EventType.DIALOGUE
+        assert event.payload["text"] == "You shall not pass!"
+        assert event.payload["emotion"] == "angry"
+        assert event.is_social_event() is True
+
+    def test_create_travel_event(self):
+        universe_id = uuid4()
+        traveler_id = uuid4()
+        from_loc = uuid4()
+        to_loc = uuid4()
+
+        event = create_travel_event(
+            universe_id=universe_id,
+            traveler_id=traveler_id,
+            from_location_id=from_loc,
+            to_location_id=to_loc,
+        )
+
+        assert event.event_type == EventType.TRAVEL
+        assert event.is_movement_event() is True
+
+    def test_create_fork_event(self):
+        parent_id = uuid4()
+        child_id = uuid4()
+        actor_id = uuid4()
+
+        event = create_fork_event(
+            parent_universe_id=parent_id,
+            child_universe_id=child_id,
+            actor_id=actor_id,
+            fork_reason="Player chose to spare the villain",
+        )
+
+        assert event.event_type == EventType.FORK
+        assert event.payload["parent_universe_id"] == parent_id
+        assert event.payload["fork_reason"] == "Player chose to spare the villain"
+
+    def test_event_types_coverage(self):
+        """Ensure all expected event types exist."""
+        expected_types = [
+            "ATTACK",
+            "DIALOGUE",
+            "TRAVEL",
+            "FORK",
+            "SHORT_REST",
+            "LONG_REST",
+            "SKILL_CHECK",
+            "SAVING_THROW",
+        ]
+        for t in expected_types:
+            assert hasattr(EventType, t)
+
+
+# --- Universe Tests ---
+
+
+class TestUniverse:
+    """Tests for Universe model."""
+
+    def test_create_prime_material(self):
+        prime = create_prime_material()
+
+        assert prime.name == "Prime Material"
+        assert prime.is_prime_material() is True
+        assert prime.parent_universe_id is None
+        assert prime.depth == 0
+        assert prime.dolt_branch == "main"
+        assert prime.is_shared is True
+
+    def test_create_fork(self):
+        prime = create_prime_material()
+        player_id = uuid4()
+
+        forked = create_fork(
+            parent=prime,
+            name="What if timeline",
+            owner_id=player_id,
+            fork_reason="Player wanted to explore alternative",
+        )
+
+        assert forked.parent_universe_id == prime.id
+        assert forked.depth == 1
+        assert forked.owner_id == player_id
+        assert forked.is_shared is False
+        assert "user/" in forked.dolt_branch
+
+    def test_nested_forks_increment_depth(self):
+        prime = create_prime_material()
+        fork1 = create_fork(prime, "Fork 1")
+        fork2 = create_fork(fork1, "Fork 2")
+        fork3 = create_fork(fork2, "Fork 3")
+
+        assert fork1.depth == 1
+        assert fork2.depth == 2
+        assert fork3.depth == 3
+
+    def test_universe_status(self):
+        prime = create_prime_material()
+        assert prime.status == UniverseStatus.ACTIVE
+        assert prime.is_active() is True
+
+        prime.status = UniverseStatus.ARCHIVED
+        assert prime.is_active() is False
+
+
+# --- Relationship Tests ---
+
+
+class TestRelationship:
+    """Tests for Relationship models."""
+
+    def test_create_knows_relationship(self):
+        universe_id = uuid4()
+        char1 = uuid4()
+        char2 = uuid4()
+
+        rel = create_knows_relationship(
+            universe_id=universe_id,
+            from_id=char1,
+            to_id=char2,
+            trust=0.8,
+            familiarity=0.6,
+        )
+
+        assert rel.relationship_type == RelationshipType.KNOWS
+        assert rel.from_entity_id == char1
+        assert rel.to_entity_id == char2
+        assert rel.trust == 0.8
+        assert rel.familiarity == 0.6
+
+    def test_create_located_in(self):
+        universe_id = uuid4()
+        char_id = uuid4()
+        location_id = uuid4()
+
+        rel = create_located_in(
+            universe_id=universe_id,
+            entity_id=char_id,
+            location_id=location_id,
+        )
+
+        assert rel.relationship_type == RelationshipType.LOCATED_IN
+        assert rel.from_entity_id == char_id
+        assert rel.to_entity_id == location_id
+        assert rel.is_current is True
+
+    def test_create_variant_relationship(self):
+        original_id = uuid4()
+        variant_id = uuid4()
+        universe_id = uuid4()
+        event_id = uuid4()
+
+        rel = create_variant(
+            original_entity_id=original_id,
+            variant_entity_id=variant_id,
+            variant_universe_id=universe_id,
+            diverged_at_event_id=event_id,
+            changes={"is_alive": "false"},
+        )
+
+        assert rel.relationship_type == RelationshipType.VARIANT_OF
+        assert rel.from_entity_id == variant_id
+        assert rel.to_entity_id == original_id
+        assert rel.changes_from_original == {"is_alive": "false"}
+
+    def test_relationship_types_coverage(self):
+        """Ensure key relationship types exist."""
+        expected = [
+            "KNOWS",
+            "LOCATED_IN",
+            "FEARS",
+            "DESIRES",
+            "VARIANT_OF",
+            "CAUSED",
+            "HAS_ATMOSPHERE",
+        ]
+        for t in expected:
+            assert hasattr(RelationshipType, t)
+
+
+# --- Integration Tests ---
+
+
+class TestOntologyIntegration:
+    """Integration tests for the full ontology."""
+
+    def test_character_in_location(self):
+        """Test creating a character and placing them in a location."""
+        universe_id = uuid4()
+
+        tavern = create_location(
+            universe_id=universe_id,
+            name="The Prancing Pony",
+            terrain="urban",
+        )
+
+        strider = create_character(
+            universe_id=universe_id,
+            name="Strider",
+            description="A mysterious ranger",
+            location_id=tavern.id,
+        )
+
+        assert strider.current_location_id == tavern.id
+
+    def test_event_chain(self):
+        """Test creating a chain of causally related events."""
+        universe_id = uuid4()
+        actor_id = uuid4()
+        target_id = uuid4()
+
+        attack = create_combat_event(
+            universe_id=universe_id,
+            actor_id=actor_id,
+            event_type=EventType.ATTACK,
+            target_id=target_id,
+            attack_roll=20,
+            damage=15,
+            is_critical=True,
+            outcome=EventOutcome.CRITICAL_SUCCESS,
+        )
+
+        # Death event caused by the attack
+        death = Event(
+            universe_id=universe_id,
+            event_type=EventType.DEATH,
+            actor_id=target_id,  # The one who died
+            outcome=EventOutcome.NEUTRAL,
+            caused_by_event_id=attack.id,
+            narrative_summary="The goblin falls lifeless to the ground.",
+        )
+
+        assert death.caused_by_event_id == attack.id
+
+    def test_timeline_fork_with_variant(self):
+        """Test forking a universe and creating entity variants."""
+        prime = create_prime_material()
+        king_id = uuid4()
+
+        # Create a fork where the king dies
+        fork = create_fork(
+            parent=prime,
+            name="King Dies Timeline",
+            fork_reason="The assassination succeeded",
+        )
+
+        # In the fork, create a variant of the king who is dead
+        variant_king_id = uuid4()
+        variant_rel = create_variant(
+            original_entity_id=king_id,
+            variant_entity_id=variant_king_id,
+            variant_universe_id=fork.id,
+            changes={"is_alive": "false", "cause_of_death": "assassination"},
+        )
+
+        assert fork.parent_universe_id == prime.id
+        assert variant_rel.changes_from_original["is_alive"] == "false"


### PR DESCRIPTION
## Summary
- Implements the core data models from specs/ontology.md
- Defines the "dual-state" architecture: Dolt (Truth) + Neo4j (Context)
- 25 new tests (173 total)

## New Model Files

| File | Purpose |
|------|---------|
| `entity.py` | Characters, Locations, Items, Factions |
| `event.py` | Immutable event log (atomic units of story) |
| `universe.py` | Timeline branches (Dolt integration) |
| `relationships.py` | Neo4j relationship types |

## Entity Model
- Core `Entity` with type-specific properties
- `EntityStats` for SRD combat stats
- `AbilityScores` with modifier calculation
- Factory functions for each entity type

## Event Model
- 30+ event types covering all game actions
- Type-specific payloads (combat, dialogue, travel, etc.)
- Causality chain support (`caused_by_event_id`)
- Narrative summary for LLM output

## Universe Model
- Maps to Dolt branches for Git-like versioning
- Supports forking and shared adventures
- Tracks lineage depth and ownership

## Relationship Model
- 30+ relationship types for Neo4j edges
- Specialized models (Knows, LocatedIn, Fears, VariantOf)
- Cross-timeline variant tracking

## Test plan
- [x] 173 tests pass locally
- [x] Ruff lint passes
- [x] Ruff format passes
- [x] Pyright type check passes
- [ ] CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)