### PR TITLE
feat: implement game engine phase 1 per specs/engine.md

### DIFF
--- a/src/engine/__init__.py
+++ b/src/engine/__init__.py
@@ -2,7 +2,60 @@
 Core Engine for TTA-Solo.
 
 The engine orchestrates:
-- Agent loops (DM, Rules Lawyer, Lorekeeper)
-- State management
-- Event recording
+- Intent parsing (understanding player actions)
+- Skill routing (resolving mechanics)
+- Narrative generation (responding to player)
+- Event recording (persisting state)
 """
+
+from __future__ import annotations
+
+from src.engine.game import GameEngine, NarrativeGenerator, SimpleNarrativeGenerator
+from src.engine.intent import (
+    HybridIntentParser,
+    LLMProvider,
+    MockLLMParser,
+    PatternIntentParser,
+)
+from src.engine.models import (
+    Context,
+    EngineConfig,
+    EntitySummary,
+    Intent,
+    IntentType,
+    RollSummary,
+    Session,
+    SkillResult,
+    Turn,
+    TurnResult,
+)
+from src.engine.router import CheckContext, CombatContext, RestContext, SkillRouter
+
+__all__ = [
+    # Main engine
+    "GameEngine",
+    # Models
+    "Context",
+    "EngineConfig",
+    "EntitySummary",
+    "Intent",
+    "IntentType",
+    "RollSummary",
+    "Session",
+    "SkillResult",
+    "Turn",
+    "TurnResult",
+    # Intent parsing
+    "HybridIntentParser",
+    "LLMProvider",
+    "MockLLMParser",
+    "PatternIntentParser",
+    # Skill routing
+    "CheckContext",
+    "CombatContext",
+    "RestContext",
+    "SkillRouter",
+    # Narrative
+    "NarrativeGenerator",
+    "SimpleNarrativeGenerator",
+]

--- a/src/engine/game.py
+++ b/src/engine/game.py
@@ -1,0 +1,397 @@
+"""
+Game Engine for TTA-Solo.
+
+The main orchestration layer that processes player turns.
+Coordinates intent parsing, skill execution, and narrative generation.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Protocol
+from uuid import UUID, uuid4
+
+from src.db.interfaces import DoltRepository, Neo4jRepository
+from src.engine.intent import HybridIntentParser, LLMProvider
+from src.engine.models import (
+    Context,
+    EngineConfig,
+    EntitySummary,
+    Intent,
+    IntentType,
+    Session,
+    SkillResult,
+    Turn,
+    TurnResult,
+)
+from src.engine.router import SkillRouter
+from src.models import Entity, Event, EventOutcome, EventType
+
+
+class NarrativeGenerator(Protocol):
+    """Interface for narrative generation."""
+
+    async def generate(
+        self,
+        intent: Intent,
+        context: Context,
+        skill_results: list[SkillResult],
+    ) -> str:
+        """Generate narrative response."""
+        ...
+
+
+class SimpleNarrativeGenerator:
+    """Simple template-based narrative generator for Phase 1."""
+
+    def __init__(self, tone: str = "adventure", verbosity: str = "normal") -> None:
+        self.tone = tone
+        self.verbosity = verbosity
+
+    async def generate(
+        self,
+        intent: Intent,
+        context: Context,
+        skill_results: list[SkillResult],
+    ) -> str:
+        """Generate a simple narrative from skill results."""
+        parts = []
+
+        # Add skill result descriptions
+        for result in skill_results:
+            if result.description:
+                parts.append(result.description)
+
+        # Add some flavor based on intent type
+        if not parts:
+            parts.append(self._default_narrative(intent, context))
+
+        narrative = " ".join(parts)
+
+        # Add a prompt for next action if verbose
+        if self.verbosity == "verbose":
+            narrative += "\n\nWhat do you do?"
+
+        return narrative
+
+    def _default_narrative(self, intent: Intent, context: Context) -> str:
+        """Generate default narrative for intents without skill results."""
+        defaults = {
+            IntentType.LOOK: f"You take in your surroundings in {context.location.name}.",
+            IntentType.WAIT: "Time passes...",
+            IntentType.UNCLEAR: "I'm not sure what you want to do. Could you be more specific?",
+            IntentType.ASK_QUESTION: "That's an interesting question about the world.",
+            IntentType.FORK: "You consider what might have been...",
+        }
+        return defaults.get(intent.type, "You do that.")
+
+
+@dataclass
+class GameEngine:
+    """
+    Main game engine orchestrating the game loop.
+
+    Coordinates:
+    - Intent parsing (understanding player actions)
+    - Context retrieval (getting world state)
+    - Skill execution (resolving mechanics)
+    - Event recording (persisting changes)
+    - Narrative generation (responding to player)
+    """
+
+    dolt: DoltRepository
+    neo4j: Neo4jRepository
+    config: EngineConfig = field(default_factory=EngineConfig)
+
+    # Components (initialized in __post_init__)
+    intent_parser: HybridIntentParser = field(init=False)
+    router: SkillRouter = field(init=False)
+    narrator: NarrativeGenerator = field(init=False)
+
+    # Session tracking
+    _sessions: dict[UUID, Session] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Initialize engine components."""
+        self.intent_parser = HybridIntentParser()
+        self.router = SkillRouter()
+        self.narrator = SimpleNarrativeGenerator(
+            tone=self.config.tone,
+            verbosity=self.config.verbosity,
+        )
+
+    def set_llm_provider(self, provider: LLMProvider) -> None:
+        """Set the LLM provider for intent parsing."""
+        self.intent_parser = HybridIntentParser(llm_provider=provider)
+
+    def set_narrative_generator(self, generator: NarrativeGenerator) -> None:
+        """Set a custom narrative generator."""
+        self.narrator = generator
+
+    async def start_session(
+        self,
+        universe_id: UUID,
+        character_id: UUID,
+        location_id: UUID | None = None,
+    ) -> Session:
+        """
+        Start a new game session.
+
+        Args:
+            universe_id: The timeline to play in
+            character_id: The player's character
+            location_id: Starting location (or get from character)
+
+        Returns:
+            New Session object
+        """
+        # Get character to find location if not provided
+        if location_id is None:
+            character = self.dolt.get_entity(character_id, universe_id)
+            if character and character.current_location_id:
+                location_id = character.current_location_id
+            else:
+                # Use a default location
+                location_id = uuid4()
+
+        session = Session(
+            universe_id=universe_id,
+            character_id=character_id,
+            location_id=location_id,
+            tone=self.config.tone,
+            verbosity=self.config.verbosity,
+        )
+
+        self._sessions[session.id] = session
+        return session
+
+    async def end_session(self, session_id: UUID) -> None:
+        """End a game session."""
+        self._sessions.pop(session_id, None)
+
+    def get_session(self, session_id: UUID) -> Session | None:
+        """Get an active session."""
+        return self._sessions.get(session_id)
+
+    async def process_turn(
+        self,
+        player_input: str,
+        session_id: UUID,
+    ) -> TurnResult:
+        """
+        Process a single player turn.
+
+        This is the main game loop entry point.
+
+        Args:
+            player_input: Raw text from the player
+            session_id: The active session ID
+
+        Returns:
+            TurnResult with narrative and metadata
+        """
+        start_time = time.time()
+
+        # Get session
+        session = self._sessions.get(session_id)
+        if session is None:
+            return TurnResult(
+                narrative="No active session found.",
+                turn_id=uuid4(),
+                error="Session not found",
+            )
+
+        # Create turn record
+        turn = Turn(
+            player_input=player_input,
+            universe_id=session.universe_id,
+            actor_id=session.character_id,
+            location_id=session.location_id,
+        )
+
+        try:
+            # Phase 1: Parse intent
+            turn.intent = await self.intent_parser.parse(player_input)
+
+            # Phase 2: Get context
+            turn.context = await self._get_context(session)
+
+            # Phase 3: Resolve mechanics
+            if turn.intent.type != IntentType.UNCLEAR:
+                skill_result = self.router.resolve(turn.intent, turn.context)
+                turn.skill_results.append(skill_result)
+
+                # Update location if movement succeeded
+                if turn.intent.type == IntentType.MOVE and skill_result.success:
+                    # In a real implementation, we'd resolve the destination
+                    # to an actual location ID
+                    pass
+
+            # Phase 4: Record events
+            await self._record_events(turn, session)
+
+            # Phase 5: Generate narrative
+            turn.narrative = await self.narrator.generate(
+                turn.intent,
+                turn.context,
+                turn.skill_results,
+            )
+
+        except Exception as e:
+            turn.error = str(e)
+            turn.narrative = "Something unexpected happened. What do you do?"
+
+        # Calculate processing time
+        turn.processing_time_ms = int((time.time() - start_time) * 1000)
+
+        # Update session
+        session.turn_count += 1
+        session.last_turn_at = turn.timestamp
+
+        # Build result
+        rolls = [r.to_roll_summary() for r in turn.skill_results if r.roll is not None]
+
+        return TurnResult(
+            narrative=turn.narrative,
+            rolls=rolls,
+            state_changes=self._extract_state_changes(turn.skill_results),
+            turn_id=turn.id,
+            events_created=len(turn.events_created),
+            processing_time_ms=turn.processing_time_ms,
+            error=turn.error,
+        )
+
+    async def _get_context(self, session: Session) -> Context:
+        """Build context for the current turn."""
+        # Get actor
+        actor_entity = self.dolt.get_entity(session.character_id, session.universe_id)
+        if actor_entity:
+            actor = self._entity_to_summary(actor_entity)
+        else:
+            actor = EntitySummary(
+                id=session.character_id,
+                name="Unknown",
+                type="character",
+            )
+
+        # Get location
+        location_entity = self.dolt.get_entity(session.location_id, session.universe_id)
+        if location_entity:
+            location = self._entity_to_summary(location_entity)
+        else:
+            location = EntitySummary(
+                id=session.location_id,
+                name="Unknown Location",
+                type="location",
+            )
+
+        # Get entities in location
+        entities_present = []
+        relationships = self.neo4j.get_relationships(
+            session.location_id,
+            session.universe_id,
+            relationship_type="LOCATED_IN",
+        )
+        for rel in relationships[:self.config.max_nearby_entities]:
+            entity = self.dolt.get_entity(rel.from_entity_id, session.universe_id)
+            if entity and entity.id != session.character_id:
+                entities_present.append(self._entity_to_summary(entity))
+
+        # Get recent events
+        recent_events = self.dolt.get_events(
+            session.universe_id,
+            limit=self.config.max_recent_events,
+        )
+        event_summaries = [e.narrative_summary for e in recent_events if e.narrative_summary]
+
+        return Context(
+            actor=actor,
+            location=location,
+            entities_present=entities_present,
+            recent_events=event_summaries,
+            danger_level=location_entity.location_properties.danger_level
+            if location_entity and location_entity.location_properties
+            else 0,
+        )
+
+    def _entity_to_summary(self, entity: Entity) -> EntitySummary:
+        """Convert Entity to lightweight EntitySummary."""
+        return EntitySummary(
+            id=entity.id,
+            name=entity.name,
+            type=entity.type.value,
+            description=entity.description,
+            hp_current=entity.stats.hp_current if entity.stats else None,
+            hp_max=entity.stats.hp_max if entity.stats else None,
+            ac=entity.stats.ac if entity.stats else None,
+        )
+
+    async def _record_events(self, turn: Turn, session: Session) -> None:
+        """Record events from the turn."""
+        if not turn.skill_results:
+            return
+
+        for result in turn.skill_results:
+            if turn.intent is None:
+                continue
+
+            # Map intent to event type
+            event_type = self._intent_to_event_type(turn.intent.type)
+
+            # Create event
+            event = Event(
+                universe_id=session.universe_id,
+                event_type=event_type,
+                actor_id=session.character_id,
+                target_id=turn.intent.target_id,
+                location_id=session.location_id,
+                outcome=self._result_to_outcome(result),
+                roll=result.roll,
+                payload={
+                    "intent_type": turn.intent.type.value,
+                    "description": result.description,
+                },
+                narrative_summary=result.description,
+            )
+
+            self.dolt.append_event(event)
+            turn.events_created.append(event.id)
+
+    def _intent_to_event_type(self, intent_type: IntentType) -> EventType:
+        """Map intent type to event type."""
+        mapping = {
+            IntentType.ATTACK: EventType.ATTACK,
+            IntentType.CAST_SPELL: EventType.ATTACK,
+            IntentType.TALK: EventType.DIALOGUE,
+            IntentType.PERSUADE: EventType.PERSUASION,
+            IntentType.INTIMIDATE: EventType.INTIMIDATION,
+            IntentType.DECEIVE: EventType.DECEPTION,
+            IntentType.MOVE: EventType.TRAVEL,
+            IntentType.REST: EventType.SHORT_REST,
+            IntentType.SEARCH: EventType.SKILL_CHECK,
+        }
+        return mapping.get(intent_type, EventType.SKILL_CHECK)
+
+    def _result_to_outcome(self, result: SkillResult) -> EventOutcome:
+        """Map skill result to event outcome."""
+        if result.is_critical:
+            return EventOutcome.CRITICAL_SUCCESS
+        elif result.is_fumble:
+            return EventOutcome.CRITICAL_FAILURE
+        elif result.success:
+            return EventOutcome.SUCCESS
+        else:
+            return EventOutcome.FAILURE
+
+    def _extract_state_changes(self, results: list[SkillResult]) -> list[str]:
+        """Extract state change descriptions from skill results."""
+        changes = []
+        for result in results:
+            if result.damage:
+                changes.append(f"Dealt {result.damage} damage")
+            if result.healing:
+                changes.append(f"Healed {result.healing} HP")
+            if result.conditions:
+                changes.append(f"Applied: {', '.join(result.conditions)}")
+        return changes

--- a/src/engine/intent.py
+++ b/src/engine/intent.py
@@ -1,0 +1,268 @@
+"""
+Intent Parser for TTA-Solo.
+
+Parses player input into structured Intent objects.
+Uses pattern matching for common actions, with LLM fallback for complex cases.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol
+
+from src.engine.models import Intent, IntentType
+
+
+class LLMProvider(Protocol):
+    """Interface for LLM-based intent parsing."""
+
+    async def parse_intent(self, player_input: str, context: str) -> Intent:
+        """Parse player input using LLM."""
+        ...
+
+
+# Pattern definitions for rule-based parsing
+INTENT_PATTERNS: dict[IntentType, list[re.Pattern]] = {
+    IntentType.ATTACK: [
+        re.compile(r"\b(attack|hit|strike|stab|slash|shoot|fire at)\b", re.I),
+        re.compile(r"\bi (attack|hit|strike|stab|slash|shoot)\b", re.I),
+    ],
+    IntentType.CAST_SPELL: [
+        re.compile(r"\b(cast|use spell|cast spell)\b", re.I),
+        re.compile(r"\bi cast\b", re.I),
+    ],
+    IntentType.TALK: [
+        re.compile(r'\b(say|tell|ask|speak|talk)\b.*["\']', re.I),
+        re.compile(r"\bi (say|tell|ask|speak to|talk to)\b", re.I),
+    ],
+    IntentType.PERSUADE: [
+        re.compile(r"\b(persuade|convince|negotiate)\b", re.I),
+    ],
+    IntentType.INTIMIDATE: [
+        re.compile(r"\b(intimidate|threaten|scare)\b", re.I),
+    ],
+    IntentType.DECEIVE: [
+        re.compile(r"\b(lie|deceive|trick|bluff)\b", re.I),
+    ],
+    IntentType.MOVE: [
+        re.compile(r"\b(go|walk|run|move|head|travel)\s+(to|towards?|into?)\b", re.I),
+        re.compile(r"\b(go|walk|run|move|head)\s+(north|south|east|west|up|down)\b", re.I),
+        re.compile(r"\b(enter|leave|exit)\b", re.I),
+    ],
+    IntentType.LOOK: [
+        re.compile(r"\b(look|examine|inspect|observe|watch)\b", re.I),
+        re.compile(r"\bwhat do i see\b", re.I),
+    ],
+    IntentType.SEARCH: [
+        re.compile(r"\b(search|investigate|check|look for)\b", re.I),
+    ],
+    IntentType.INTERACT: [
+        re.compile(r"\b(open|close|push|pull|use|activate|touch)\b", re.I),
+    ],
+    IntentType.USE_ITEM: [
+        re.compile(r"\b(use|drink|eat|apply|read)\s+(my|the|a)\b", re.I),
+    ],
+    IntentType.PICK_UP: [
+        re.compile(r"\b(pick up|grab|collect|get)\b", re.I),
+        re.compile(r"\btake\s+(?:the\s+)?(?!a\s+(?:short|long)\s+rest)", re.I),  # "take X" but not "take a rest"
+    ],
+    IntentType.DROP: [
+        re.compile(r"\b(drop|put down|discard|throw away)\b", re.I),
+    ],
+    IntentType.GIVE: [
+        re.compile(r"\b(give|hand|offer|pass)\b.*\bto\b", re.I),
+    ],
+    IntentType.REST: [
+        re.compile(r"\b(rest|take a (short|long) rest|sleep|camp)\b", re.I),
+    ],
+    IntentType.WAIT: [
+        re.compile(r"\b(wait|stay|remain|do nothing)\b", re.I),
+    ],
+    IntentType.ASK_QUESTION: [
+        re.compile(r"^(what|where|who|why|how|when)\s+(is|are|was|were|do|does|did|can|could)\b", re.I),
+    ],
+    IntentType.FORK: [
+        re.compile(r"\bwhat if\b", re.I),
+        re.compile(r"\blet'?s go back\b", re.I),
+        re.compile(r"\bundo\b", re.I),
+    ],
+}
+
+# Target extraction patterns
+TARGET_PATTERNS = [
+    re.compile(r"\b(?:the|a|an)\s+(\w+(?:\s+\w+)?)\b", re.I),  # "the goblin"
+    re.compile(r"\bat\s+(?:the\s+)?(\w+(?:\s+\w+)?)\b", re.I),  # "at the door"
+    re.compile(r"\bto\s+(?:the\s+)?(\w+(?:\s+\w+)?)\b", re.I),  # "to the merchant"
+]
+
+# Direction extraction for MOVE
+DIRECTION_PATTERN = re.compile(
+    r"\b(north|south|east|west|up|down|left|right|forward|back|inside|outside)\b", re.I
+)
+
+# Dialogue extraction for TALK
+DIALOGUE_PATTERN = re.compile(r'["\'](.+?)["\']', re.I)
+
+
+def extract_target(text: str) -> str | None:
+    """Extract target from player input."""
+    for pattern in TARGET_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def extract_destination(text: str) -> str | None:
+    """Extract movement destination from player input."""
+    match = DIRECTION_PATTERN.search(text)
+    if match:
+        return match.group(1).lower()
+
+    # Try extracting location name
+    location_pattern = re.compile(
+        r"\b(?:go|walk|run|move|head|travel)\s+(?:to|towards?|into?)\s+(?:the\s+)?(.+?)(?:\.|$)",
+        re.I,
+    )
+    match = location_pattern.search(text)
+    if match:
+        return match.group(1).strip()
+
+    return None
+
+
+def extract_dialogue(text: str) -> str | None:
+    """Extract quoted dialogue from player input."""
+    match = DIALOGUE_PATTERN.search(text)
+    if match:
+        return match.group(1)
+    return None
+
+
+class PatternIntentParser:
+    """Rule-based intent parser using regex patterns."""
+
+    def parse(self, player_input: str) -> Intent:
+        """
+        Parse player input into an Intent using pattern matching.
+
+        Args:
+            player_input: Raw text from the player
+
+        Returns:
+            Intent object with parsed information
+        """
+        text = player_input.strip()
+
+        # Try each intent type's patterns
+        matched_type = IntentType.UNCLEAR
+        confidence = 0.5
+
+        for intent_type, patterns in INTENT_PATTERNS.items():
+            for pattern in patterns:
+                if pattern.search(text):
+                    matched_type = intent_type
+                    confidence = 0.8
+                    break
+            if matched_type != IntentType.UNCLEAR:
+                break
+
+        # Extract additional information based on intent type
+        target_name = extract_target(text)
+        destination = None
+        dialogue = None
+        method = None
+
+        if matched_type == IntentType.MOVE:
+            destination = extract_destination(text)
+            target_name = None  # Don't confuse destination with target
+
+        elif matched_type == IntentType.TALK:
+            dialogue = extract_dialogue(text)
+
+        elif matched_type == IntentType.ATTACK:
+            # Try to extract weapon/method
+            weapon_pattern = re.compile(r"\bwith\s+(?:my\s+)?(.+?)(?:\.|$)", re.I)
+            match = weapon_pattern.search(text)
+            if match:
+                method = match.group(1).strip()
+
+        return Intent(
+            type=matched_type,
+            confidence=confidence,
+            target_name=target_name,
+            destination=destination,
+            dialogue=dialogue,
+            method=method,
+            original_input=text,
+            reasoning=f"Matched pattern for {matched_type.value}",
+        )
+
+
+class MockLLMParser:
+    """Mock LLM parser for testing."""
+
+    def __init__(self, default_intent_type: IntentType = IntentType.UNCLEAR) -> None:
+        self.default_intent_type = default_intent_type
+        self.call_count = 0
+
+    async def parse_intent(self, player_input: str, context: str = "") -> Intent:
+        """Return a mock intent for testing."""
+        self.call_count += 1
+
+        # Use pattern parser as base, but mark as LLM-parsed
+        pattern_parser = PatternIntentParser()
+        intent = pattern_parser.parse(player_input)
+
+        # Override if pattern couldn't determine
+        if intent.type == IntentType.UNCLEAR:
+            intent.type = self.default_intent_type
+
+        intent.confidence = 0.95
+        intent.reasoning = "Parsed by MockLLM"
+        return intent
+
+
+class HybridIntentParser:
+    """
+    Hybrid intent parser combining pattern matching and LLM.
+
+    Uses fast pattern matching for clear intents,
+    falls back to LLM for ambiguous cases.
+    """
+
+    def __init__(
+        self,
+        llm_provider: LLMProvider | None = None,
+        confidence_threshold: float = 0.7,
+    ) -> None:
+        self.pattern_parser = PatternIntentParser()
+        self.llm_provider = llm_provider
+        self.confidence_threshold = confidence_threshold
+
+    async def parse(self, player_input: str, context: str = "") -> Intent:
+        """
+        Parse player input, using LLM if pattern matching is uncertain.
+
+        Args:
+            player_input: Raw text from the player
+            context: Optional context string for LLM
+
+        Returns:
+            Intent object with parsed information
+        """
+        # Try pattern matching first
+        intent = self.pattern_parser.parse(player_input)
+
+        # If confident enough, return pattern result
+        if intent.confidence >= self.confidence_threshold:
+            return intent
+
+        # Fall back to LLM if available
+        if self.llm_provider is not None:
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                intent = await self.llm_provider.parse_intent(player_input, context)
+
+        return intent

--- a/src/engine/router.py
+++ b/src/engine/router.py
@@ -1,0 +1,321 @@
+"""
+Skill Router for TTA-Solo.
+
+Maps Intent types to skill functions and executes them.
+This is the "Rules Lawyer" component in the engine architecture.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from src.engine.models import Context, Intent, IntentType, SkillResult
+from src.skills.checks import SkillProficiencies, skill_check
+from src.skills.combat import Combatant, Weapon, resolve_attack
+from src.skills.rest import CharacterResources, HitDice, take_long_rest, take_short_rest
+
+if TYPE_CHECKING:
+    pass
+
+
+class CombatContext(BaseModel):
+    """Context needed for combat resolution."""
+
+    attacker: Combatant
+    target: Combatant
+    weapon: Weapon
+
+
+class CheckContext(BaseModel):
+    """Context needed for skill/ability checks."""
+
+    entity: Combatant
+    skill_proficiencies: SkillProficiencies | None = None
+    dc: int = 10
+
+
+class RestContext(BaseModel):
+    """Context needed for rest resolution."""
+
+    resources: CharacterResources
+    is_long_rest: bool = False
+
+
+class SkillRouter:
+    """
+    Routes intents to appropriate skill functions.
+
+    Acts as the "Rules Lawyer" - handles all mechanical resolution.
+    """
+
+    def resolve(
+        self,
+        intent: Intent,
+        context: Context,
+        extra: dict[str, Any] | None = None,
+    ) -> SkillResult:
+        """
+        Resolve an intent using the appropriate skill.
+
+        Args:
+            intent: The parsed player intent
+            context: Current game context
+            extra: Additional context (combat targets, etc.)
+
+        Returns:
+            SkillResult with the outcome
+        """
+        extra = extra or {}
+
+        # Route to appropriate handler
+        if intent.type == IntentType.ATTACK:
+            return self._resolve_attack(intent, context, extra)
+
+        elif intent.type in {
+            IntentType.PERSUADE,
+            IntentType.INTIMIDATE,
+            IntentType.DECEIVE,
+            IntentType.SEARCH,
+        }:
+            return self._resolve_skill_check(intent, context, extra)
+
+        elif intent.type == IntentType.REST:
+            return self._resolve_rest(intent, context, extra)
+
+        elif intent.type == IntentType.LOOK:
+            return self._resolve_look(intent, context)
+
+        elif intent.type == IntentType.MOVE:
+            return self._resolve_move(intent, context)
+
+        elif intent.type == IntentType.TALK:
+            return self._resolve_talk(intent, context)
+
+        else:
+            # For intents without mechanical resolution
+            return SkillResult(
+                success=True,
+                outcome="neutral",
+                description=f"Action: {intent.type.value}",
+            )
+
+    def _resolve_attack(
+        self,
+        intent: Intent,
+        context: Context,
+        extra: dict[str, Any],
+    ) -> SkillResult:
+        """Resolve an attack action."""
+        combat_ctx = extra.get("combat")
+
+        if combat_ctx is None:
+            # Build combat context from game context
+            # Create attacker from actor stats
+            attacker = Combatant(
+                name=context.actor.name,
+                ac=context.actor.ac or 10,
+                proficiency_bonus=2,
+                proficient_weapons=["longsword", "shortbow"],  # Default proficiencies
+            )
+
+            # Find target in present entities
+            target_ac = 10
+            target_name = intent.target_name or "target"
+            if intent.target_name:
+                for entity in context.entities_present:
+                    if intent.target_name.lower() in entity.name.lower():
+                        target_ac = entity.ac or 10
+                        target_name = entity.name
+                        break
+
+            target = Combatant(
+                name=target_name,
+                ac=target_ac,
+            )
+
+            # Default weapon
+            weapon = Weapon(
+                name="longsword",
+                damage_dice="1d8",
+                damage_type="slashing",
+            )
+
+            combat_ctx = CombatContext(attacker=attacker, target=target, weapon=weapon)
+
+        # Resolve the attack
+        result = resolve_attack(
+            attacker=combat_ctx.attacker,
+            target=combat_ctx.target,
+            weapon=combat_ctx.weapon,
+        )
+
+        return SkillResult(
+            success=result.hit,
+            outcome="critical_success" if result.critical else ("success" if result.hit else "failure"),
+            roll=result.attack_roll,
+            total=result.total_attack,
+            dc=combat_ctx.target.ac,
+            damage=result.damage if result.hit else None,
+            description=self._format_attack_result(result, intent),
+            is_critical=result.critical,
+            is_fumble=result.fumble,
+        )
+
+    def _format_attack_result(self, result: Any, intent: Intent) -> str:
+        """Format attack result for display."""
+        target = intent.target_name or "the target"
+
+        if result.fumble:
+            return "Critical miss! The attack goes wildly off target."
+        elif result.critical:
+            return f"Critical hit on {target}! Rolled {result.attack_roll} (crit). {result.damage} damage!"
+        elif result.hit:
+            return f"Hit {target}! Rolled {result.total_attack} vs AC {result.target_ac}. {result.damage} damage."
+        else:
+            return f"Missed {target}. Rolled {result.total_attack} vs AC {result.target_ac}."
+
+    def _resolve_skill_check(
+        self,
+        intent: Intent,
+        context: Context,
+        extra: dict[str, Any],
+    ) -> SkillResult:
+        """Resolve a skill check."""
+        check_ctx = extra.get("check")
+
+        # Map intent to skill name
+        skill_map = {
+            IntentType.PERSUADE: "persuasion",
+            IntentType.INTIMIDATE: "intimidation",
+            IntentType.DECEIVE: "deception",
+            IntentType.SEARCH: "investigation",
+        }
+        skill_name = skill_map.get(intent.type, "perception")
+
+        if check_ctx is None:
+            # Create a default entity for the check
+            entity = Combatant(
+                name=context.actor.name,
+                ac=context.actor.ac or 10,
+            )
+            check_ctx = CheckContext(
+                entity=entity,
+                dc=10,
+            )
+
+        result = skill_check(
+            entity=check_ctx.entity,
+            skill=skill_name,
+            dc=check_ctx.dc,
+            skill_proficiencies=check_ctx.skill_proficiencies,
+        )
+
+        # Determine critical success/failure based on roll
+        is_critical = result.roll == 20
+        is_fumble = result.roll == 1
+
+        return SkillResult(
+            success=result.success,
+            outcome="critical_success" if is_critical and result.success else (
+                "critical_failure" if is_fumble and not result.success else (
+                    "success" if result.success else "failure"
+                )
+            ),
+            roll=result.roll,
+            total=result.total,
+            dc=result.dc,
+            description=f"{skill_name.title()} check: {result.total} vs DC {result.dc}. {'Success!' if result.success else 'Failed.'}",
+            is_critical=is_critical and result.success,
+            is_fumble=is_fumble and not result.success,
+        )
+
+    def _resolve_rest(
+        self,
+        intent: Intent,
+        context: Context,
+        extra: dict[str, Any],
+    ) -> SkillResult:
+        """Resolve a rest action."""
+        rest_ctx = extra.get("rest")
+
+        if rest_ctx is None:
+            # Create default resources
+            hp_max = context.actor.hp_max or 10
+            rest_ctx = RestContext(
+                resources=CharacterResources(
+                    hp_current=context.actor.hp_current or hp_max,
+                    hp_max=hp_max,
+                    hit_dice=HitDice(die_type="d8", total=1, current=1),
+                ),
+                is_long_rest="long" in intent.original_input.lower(),
+            )
+
+        if rest_ctx.is_long_rest:
+            result = take_long_rest(rest_ctx.resources)
+            rest_type = "long rest"
+        else:
+            result = take_short_rest(rest_ctx.resources, hit_dice_to_spend=1)
+            rest_type = "short rest"
+
+        return SkillResult(
+            success=True,
+            outcome="success",
+            healing=result.hp_healed,
+            description=f"Completed a {rest_type}. Healed {result.hp_healed} HP.",
+        )
+
+    def _resolve_look(self, intent: Intent, context: Context) -> SkillResult:
+        """Resolve a look/examine action."""
+        # Build description from context
+        parts = []
+
+        if context.location:
+            parts.append(f"You are in {context.location.name}.")
+            if context.location.description:
+                parts.append(context.location.description)
+
+        if context.entities_present:
+            entity_names = [e.name for e in context.entities_present]
+            parts.append(f"You see: {', '.join(entity_names)}.")
+
+        if context.exits:
+            parts.append(f"Exits: {', '.join(context.exits)}.")
+
+        description = " ".join(parts) if parts else "You look around but see nothing notable."
+
+        return SkillResult(
+            success=True,
+            outcome="neutral",
+            description=description,
+        )
+
+    def _resolve_move(self, intent: Intent, context: Context) -> SkillResult:
+        """Resolve a movement action."""
+        destination = intent.destination or "forward"
+
+        # Check if destination is valid
+        if context.exits and destination.lower() not in [e.lower() for e in context.exits]:
+            return SkillResult(
+                success=False,
+                outcome="failure",
+                description=f"You can't go {destination} from here.",
+            )
+
+        return SkillResult(
+            success=True,
+            outcome="success",
+            description=f"You move {destination}.",
+        )
+
+    def _resolve_talk(self, intent: Intent, context: Context) -> SkillResult:
+        """Resolve a talk/speak action."""
+        target = intent.target_name or "no one in particular"
+        dialogue = intent.dialogue or "something"
+
+        return SkillResult(
+            success=True,
+            outcome="neutral",
+            description=f'You say to {target}: "{dialogue}"',
+        )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,471 @@
+"""Tests for the game engine components."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from src.db.memory import InMemoryDoltRepository, InMemoryNeo4jRepository
+from src.engine import (
+    Context,
+    EntitySummary,
+    GameEngine,
+    HybridIntentParser,
+    Intent,
+    IntentType,
+    MockLLMParser,
+    PatternIntentParser,
+    Session,
+    SkillRouter,
+    TurnResult,
+)
+from src.models import create_character, create_location, create_prime_material
+
+# --- Intent Parser Tests ---
+
+
+class TestPatternIntentParser:
+    """Tests for pattern-based intent parsing."""
+
+    @pytest.fixture
+    def parser(self) -> PatternIntentParser:
+        return PatternIntentParser()
+
+    def test_parse_attack(self, parser: PatternIntentParser):
+        intent = parser.parse("I attack the goblin")
+        assert intent.type == IntentType.ATTACK
+        assert intent.target_name == "goblin"
+
+    def test_parse_attack_with_weapon(self, parser: PatternIntentParser):
+        intent = parser.parse("I attack the orc with my sword")
+        assert intent.type == IntentType.ATTACK
+        assert intent.method == "sword"
+
+    def test_parse_move_direction(self, parser: PatternIntentParser):
+        intent = parser.parse("I go north")
+        assert intent.type == IntentType.MOVE
+        assert intent.destination == "north"
+
+    def test_parse_move_to_location(self, parser: PatternIntentParser):
+        intent = parser.parse("I walk to the tavern")
+        assert intent.type == IntentType.MOVE
+        assert "tavern" in intent.destination.lower()
+
+    def test_parse_look(self, parser: PatternIntentParser):
+        intent = parser.parse("I look around")
+        assert intent.type == IntentType.LOOK
+
+    def test_parse_examine(self, parser: PatternIntentParser):
+        intent = parser.parse("I examine the chest")
+        assert intent.type == IntentType.LOOK
+        assert intent.target_name == "chest"
+
+    def test_parse_talk_with_dialogue(self, parser: PatternIntentParser):
+        intent = parser.parse('I say "Hello there" to the merchant')
+        assert intent.type == IntentType.TALK
+        assert intent.dialogue == "Hello there"
+
+    def test_parse_persuade(self, parser: PatternIntentParser):
+        intent = parser.parse("I try to persuade the guard to let us pass")
+        assert intent.type == IntentType.PERSUADE
+
+    def test_parse_intimidate(self, parser: PatternIntentParser):
+        intent = parser.parse("I intimidate the bandit")
+        assert intent.type == IntentType.INTIMIDATE
+
+    def test_parse_search(self, parser: PatternIntentParser):
+        intent = parser.parse("I search the room for hidden doors")
+        assert intent.type == IntentType.SEARCH
+
+    def test_parse_pick_up(self, parser: PatternIntentParser):
+        intent = parser.parse("I pick up the gold coins")
+        assert intent.type == IntentType.PICK_UP
+
+    def test_parse_rest_short(self, parser: PatternIntentParser):
+        intent = parser.parse("I take a short rest")
+        assert intent.type == IntentType.REST
+        assert "short" in intent.original_input.lower()
+
+    def test_parse_rest_long(self, parser: PatternIntentParser):
+        intent = parser.parse("I want to take a long rest")
+        assert intent.type == IntentType.REST
+        assert "long" in intent.original_input.lower()
+
+    def test_parse_wait(self, parser: PatternIntentParser):
+        intent = parser.parse("I wait here")
+        assert intent.type == IntentType.WAIT
+
+    def test_parse_fork(self, parser: PatternIntentParser):
+        intent = parser.parse("What if I had attacked instead?")
+        assert intent.type == IntentType.FORK
+
+    def test_parse_unclear(self, parser: PatternIntentParser):
+        intent = parser.parse("asdfghjkl")
+        assert intent.type == IntentType.UNCLEAR
+
+    def test_confidence_on_clear_match(self, parser: PatternIntentParser):
+        intent = parser.parse("I attack the dragon")
+        assert intent.confidence >= 0.7
+
+    def test_confidence_on_unclear(self, parser: PatternIntentParser):
+        intent = parser.parse("hmm maybe I dunno")
+        assert intent.confidence < 0.7
+
+
+class TestHybridIntentParser:
+    """Tests for hybrid intent parsing."""
+
+    @pytest.mark.asyncio
+    async def test_uses_pattern_when_confident(self):
+        parser = HybridIntentParser(llm_provider=None)
+        intent = await parser.parse("I attack the goblin")
+        assert intent.type == IntentType.ATTACK
+
+    @pytest.mark.asyncio
+    async def test_uses_llm_when_uncertain(self):
+        mock_llm = MockLLMParser(default_intent_type=IntentType.INTERACT)
+        parser = HybridIntentParser(
+            llm_provider=mock_llm,
+            confidence_threshold=0.9,  # High threshold to trigger LLM
+        )
+        await parser.parse("I fiddle with the thing")
+        # Should have called the LLM
+        assert mock_llm.call_count > 0
+
+    @pytest.mark.asyncio
+    async def test_works_without_llm(self):
+        parser = HybridIntentParser(llm_provider=None)
+        intent = await parser.parse("random gibberish")
+        assert intent.type == IntentType.UNCLEAR
+
+
+# --- Skill Router Tests ---
+
+
+class TestSkillRouter:
+    """Tests for skill routing."""
+
+    @pytest.fixture
+    def router(self) -> SkillRouter:
+        return SkillRouter()
+
+    @pytest.fixture
+    def basic_context(self) -> Context:
+        return Context(
+            actor=EntitySummary(
+                id=uuid4(),
+                name="Hero",
+                type="character",
+                hp_current=20,
+                hp_max=20,
+                ac=15,
+            ),
+            location=EntitySummary(
+                id=uuid4(),
+                name="Tavern",
+                type="location",
+            ),
+            entities_present=[
+                EntitySummary(
+                    id=uuid4(),
+                    name="Goblin",
+                    type="character",
+                    ac=12,
+                ),
+            ],
+            exits=["north", "south"],
+        )
+
+    def test_resolve_attack(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.ATTACK,
+            confidence=0.9,
+            target_name="goblin",
+            original_input="I attack the goblin",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.roll is not None
+        assert result.description  # Should have a description
+
+    def test_resolve_skill_check(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.PERSUADE,
+            confidence=0.9,
+            original_input="I try to persuade",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.roll is not None
+        assert result.dc is not None
+        assert "persuasion" in result.description.lower()
+
+    def test_resolve_look(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.LOOK,
+            confidence=0.9,
+            original_input="I look around",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.success
+        assert "Tavern" in result.description
+        assert "Goblin" in result.description
+
+    def test_resolve_move_valid(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.MOVE,
+            confidence=0.9,
+            destination="north",
+            original_input="I go north",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.success
+        assert "north" in result.description.lower()
+
+    def test_resolve_move_invalid(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.MOVE,
+            confidence=0.9,
+            destination="east",  # Not in exits
+            original_input="I go east",
+        )
+        result = router.resolve(intent, basic_context)
+        assert not result.success
+        assert "can't" in result.description.lower()
+
+    def test_resolve_talk(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.TALK,
+            confidence=0.9,
+            target_name="goblin",
+            dialogue="Hello!",
+            original_input='I say "Hello!" to the goblin',
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.success
+        assert "Hello!" in result.description
+
+    def test_resolve_rest_short(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.REST,
+            confidence=0.9,
+            original_input="I take a short rest",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.success
+        assert "short rest" in result.description.lower()
+
+    def test_resolve_rest_long(self, router: SkillRouter, basic_context: Context):
+        intent = Intent(
+            type=IntentType.REST,
+            confidence=0.9,
+            original_input="I take a long rest",
+        )
+        result = router.resolve(intent, basic_context)
+        assert result.success
+        assert "long rest" in result.description.lower()
+
+
+# --- Game Engine Tests ---
+
+
+class TestGameEngine:
+    """Tests for the main game engine."""
+
+    @pytest.fixture
+    def engine(self) -> GameEngine:
+        dolt = InMemoryDoltRepository()
+        neo4j = InMemoryNeo4jRepository()
+        return GameEngine(dolt=dolt, neo4j=neo4j)
+
+    @pytest.fixture
+    def setup_world(self, engine: GameEngine) -> tuple[GameEngine, Session]:
+        """Set up a basic game world and return engine with session."""
+        # Create universe
+        universe = create_prime_material()
+        engine.dolt.save_universe(universe)
+
+        # Create location
+        tavern = create_location(
+            universe_id=universe.id,
+            name="The Rusty Dragon",
+            description="A cozy tavern",
+        )
+        engine.dolt.save_entity(tavern)
+
+        # Create character
+        hero = create_character(
+            universe_id=universe.id,
+            name="Valeros",
+            hp_max=20,
+            ac=16,
+            location_id=tavern.id,
+        )
+        engine.dolt.save_entity(hero)
+
+        return engine, universe, hero, tavern
+
+    @pytest.mark.asyncio
+    async def test_start_session(self, engine: GameEngine):
+        universe_id = uuid4()
+        character_id = uuid4()
+        location_id = uuid4()
+
+        session = await engine.start_session(
+            universe_id=universe_id,
+            character_id=character_id,
+            location_id=location_id,
+        )
+
+        assert session.universe_id == universe_id
+        assert session.character_id == character_id
+        assert session.location_id == location_id
+        assert session.turn_count == 0
+
+    @pytest.mark.asyncio
+    async def test_get_session(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        retrieved = engine.get_session(session.id)
+        assert retrieved is not None
+        assert retrieved.id == session.id
+
+    @pytest.mark.asyncio
+    async def test_end_session(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        await engine.end_session(session.id)
+        assert engine.get_session(session.id) is None
+
+    @pytest.mark.asyncio
+    async def test_process_turn_no_session(self, engine: GameEngine):
+        result = await engine.process_turn("I attack", uuid4())
+        assert result.error is not None
+        assert "session" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_process_turn_attack(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        result = await engine.process_turn("I attack the goblin", session.id)
+
+        assert isinstance(result, TurnResult)
+        assert result.narrative  # Should have some narrative
+        assert len(result.rolls) > 0  # Should have rolled dice
+
+    @pytest.mark.asyncio
+    async def test_process_turn_look(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        result = await engine.process_turn("I look around", session.id)
+
+        assert result.narrative
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_process_turn_increments_count(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        await engine.process_turn("I look around", session.id)
+        await engine.process_turn("I wait", session.id)
+
+        updated_session = engine.get_session(session.id)
+        assert updated_session.turn_count == 2
+
+    @pytest.mark.asyncio
+    async def test_process_turn_records_time(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        result = await engine.process_turn("I attack", session.id)
+
+        assert result.processing_time_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_unclear_intent_handled(self, engine: GameEngine):
+        session = await engine.start_session(
+            universe_id=uuid4(),
+            character_id=uuid4(),
+            location_id=uuid4(),
+        )
+
+        result = await engine.process_turn("asdfghjkl gibberish", session.id)
+
+        # Should handle gracefully
+        assert result.narrative
+        assert result.error is None
+
+
+# --- Integration Tests ---
+
+
+class TestEngineIntegration:
+    """Integration tests for the complete engine flow."""
+
+    @pytest.mark.asyncio
+    async def test_full_turn_flow(self):
+        # Set up
+        dolt = InMemoryDoltRepository()
+        neo4j = InMemoryNeo4jRepository()
+        engine = GameEngine(dolt=dolt, neo4j=neo4j)
+
+        # Create world
+        universe = create_prime_material()
+        dolt.save_universe(universe)
+
+        location = create_location(
+            universe_id=universe.id,
+            name="Forest Clearing",
+            description="A peaceful clearing in the forest.",
+        )
+        dolt.save_entity(location)
+
+        character = create_character(
+            universe_id=universe.id,
+            name="Ranger",
+            hp_max=25,
+            location_id=location.id,
+        )
+        dolt.save_entity(character)
+
+        # Start session
+        session = await engine.start_session(
+            universe_id=universe.id,
+            character_id=character.id,
+            location_id=location.id,
+        )
+
+        # Play some turns
+        result1 = await engine.process_turn("I look around", session.id)
+        assert "Forest Clearing" in result1.narrative or result1.narrative
+
+        result2 = await engine.process_turn("I search for tracks", session.id)
+        assert result2.rolls  # Should have made a check
+
+        result3 = await engine.process_turn("I take a short rest", session.id)
+        assert "rest" in result3.narrative.lower()
+
+        # Verify state
+        assert session.turn_count == 3


### PR DESCRIPTION
## Summary

- Implements the core game engine orchestration layer (Phase 1 from specs/engine.md)
- Adds intent parsing with pattern matching and LLM fallback support
- Routes player intents to combat, skill checks, and rest mechanics
- Includes session management, turn processing, and event recording

## Components

| File | Purpose |
|------|---------|
| `models.py` | Intent, Context, Turn, TurnResult, Session, EngineConfig |
| `intent.py` | PatternIntentParser (regex) + HybridIntentParser (LLM fallback) |
| `router.py` | SkillRouter maps intents → combat/checks/rest skills |
| `game.py` | GameEngine orchestrates the 5-phase game loop |

## Game Loop (5 Phases)

1. **Parse** - Extract intent from player input
2. **Context** - Retrieve world state from Dolt/Neo4j
3. **Resolve** - Execute mechanics via skill router
4. **Record** - Persist events to Dolt
5. **Narrate** - Generate response to player

## Test plan

- [x] 39 new tests for engine components
- [x] All 263 tests passing
- [x] Lint and type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)